### PR TITLE
Fix incorrect output example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Tetouan 48.50
 gaz 1.30
 potato 3.50
 tomato 3.50
+sugar 4.50
 flour 5.20
-oil 6.70
 ```
 
 **Explanation: Tetouan is the cheapest city because it has a total price of 48.50, while Casa has a total price of 93.73 and Rabat has a total price of 78.10.**


### PR DESCRIPTION
This Pull Request addresses an inconsistency found in the README's example output for the challenge. The original example did not accurately reflect the challenge's requirements regarding the sorting and selection of the cheapest products. Specifically, it failed to include "sugar" in the list of cheapest products, which, according to the challenge rules, should be present based on its price and the alphabetical sorting criterion for products with identical prices.

![image](https://github.com/geeksblabla/blanat/assets/114141528/1e81b8dc-c95c-4c14-bba6-d6ce8893857a)

The correction ensures that the example output in the README accurately reflects the challenge's stated rules, specifically:

The output must list the first 5 cheapest products sorted by price, then alphabetically.
Products with the same price must be sorted alphabetically.