### PR TITLE
Add latest run.log after enabling go/rust solutions

### DIFF
--- a/run1.log
+++ b/run1.log
@@ -1,0 +1,17335 @@
+[2024-03-10T11:36:41Z DEBUG blarun] Results file is: /home/maxheap/blablaconf/results.csv
+[2024-03-10T11:36:41Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/HamzaMPSY/submission.cpp"
+[2024-03-10T11:36:43Z INFO  blarun] Finished compilation of the target: "/tmp/.tmph3RW2c/sol" with exit code: exit status: 0
+[2024-03-10T11:36:43Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:36:43Z DEBUG blarun] The current started process has pid: 323306
+[2024-03-10T11:36:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:43Z DEBUG blarun] Correctness execution finished in: 114.732858ms
+[2024-03-10T11:36:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:36:43Z DEBUG blarun] Comparing output "/tmp/.tmpvNFY7r/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:36:43Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/HamzaMPSY/submission.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "HamzaMPSY" } with error: No such file or directory (os error 2)
+[2024-03-10T11:36:43Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/HelloWorldszz/main.py"
+[2024-03-10T11:36:43Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:36:43Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/HelloWorldszz/main.py" to "/tmp/.tmpYmf884/main.py"
+[2024-03-10T11:36:43Z DEBUG blarun] The current started process has pid: 323323
+Traceback (most recent call last):
+  File "/tmp/.tmpYmf884/main.py", line 49, in <module>
+    main()
+  File "/tmp/.tmpYmf884/main.py", line 33, in main
+    city_prices, products = read_input_file('inputM.txt')
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/tmp/.tmpYmf884/main.py", line 11, in read_input_file
+    with open(filename, 'r') as file:
+         ^^^^^^^^^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: 'inputM.txt'
+[2024-03-10T11:36:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:43Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T11:36:43Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/HelloWorldszz/main.py", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "HelloWorldszz" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T11:36:43Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/BadRequest/script.js"
+[2024-03-10T11:36:43Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:36:43Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/BadRequest/script.js" to "/tmp/.tmpcpxy9v/main.js"
+[2024-03-10T11:36:43Z DEBUG blarun] The current started process has pid: 323324
+[2024-03-10T11:36:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:44Z DEBUG blarun] Correctness execution finished in: 302.249917ms
+[2024-03-10T11:36:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:36:44Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:36:44Z DEBUG blarun] The current started process has pid: 323335
+[2024-03-10T11:36:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:44Z DEBUG blarun] Correctness execution finished in: 279.331772ms
+[2024-03-10T11:36:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:36:44Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:36:44Z DEBUG blarun] The current started process has pid: 323346
+[2024-03-10T11:36:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:44Z DEBUG blarun] Correctness execution finished in: 288.046216ms
+[2024-03-10T11:36:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:36:44Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:36:44Z DEBUG blarun] The current started process has pid: 323357
+[2024-03-10T11:36:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:44Z DEBUG blarun] Correctness execution finished in: 278.062573ms
+[2024-03-10T11:36:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:36:44Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:36:44Z DEBUG blarun] The current started process has pid: 323368
+[2024-03-10T11:36:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:45Z DEBUG blarun] Correctness execution finished in: 282.134113ms
+[2024-03-10T11:36:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:36:45Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:36:45Z DEBUG blarun] The current started process has pid: 323379
+[2024-03-10T11:36:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:45Z DEBUG blarun] Correctness execution finished in: 280.795136ms
+[2024-03-10T11:36:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:36:45Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:36:45Z DEBUG blarun] The current started process has pid: 323390
+[2024-03-10T11:36:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:45Z DEBUG blarun] Correctness execution finished in: 280.504776ms
+[2024-03-10T11:36:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:36:45Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:36:45Z DEBUG blarun] The current started process has pid: 323401
+[2024-03-10T11:36:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:46Z DEBUG blarun] Correctness execution finished in: 277.84629ms
+[2024-03-10T11:36:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:36:46Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:36:46Z DEBUG blarun] The current started process has pid: 323412
+[2024-03-10T11:36:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:46Z DEBUG blarun] Correctness execution finished in: 278.712659ms
+[2024-03-10T11:36:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:36:46Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:36:46Z DEBUG blarun] The current started process has pid: 323423
+[2024-03-10T11:36:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:36:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:36:46Z DEBUG blarun] Correctness execution finished in: 276.040346ms
+[2024-03-10T11:36:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:36:46Z DEBUG blarun] Comparing output "/tmp/.tmpcpxy9v/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:36:46Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T11:36:46Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpj9ILlh/input.txt"
+[2024-03-10T11:36:46Z DEBUG blarun] The current started process has pid: 323434
+[2024-03-10T11:36:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:46Z DEBUG blarun] Child process timed out
+[2024-03-10T11:46:46Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T11:46:46Z INFO  blarun] Submission from user: BadRequest has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:46:46Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mohammedfatihX/Main.java"
+[2024-03-10T11:46:47Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpFntTlo/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:47Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:46:47Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/mohammedfatihX/Main.java" to "/tmp/.tmpbHT3Fg/Main.java"
+[2024-03-10T11:46:47Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:46:48Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpbHT3Fg/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:48Z DEBUG blarun] The current started process has pid: 323554
+[2024-03-10T11:46:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:48Z DEBUG blarun] Correctness execution finished in: 318.940755ms
+[2024-03-10T11:46:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:48Z DEBUG blarun] Comparing output "/tmp/.tmpbHT3Fg/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:48Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T11:46:48Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T11:46:48Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T11:46:48Z INFO  blarun] Submission from user: mohammedfatihX has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:46:48Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ayoubkassi/GeeksChallenge.java"
+[2024-03-10T11:46:49Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpVXSBdm/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:49Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:46:49Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ayoubkassi/GeeksChallenge.java" to "/tmp/.tmpDHVKGn/Main.java"
+[2024-03-10T11:46:49Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:46:49Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpDHVKGn/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:49Z DEBUG blarun] The current started process has pid: 323668
+[2024-03-10T11:46:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:50Z DEBUG blarun] Correctness execution finished in: 264.818743ms
+[2024-03-10T11:46:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:50Z DEBUG blarun] Comparing output "/tmp/.tmpDHVKGn/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:50Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Kiwi 1.00
+    Chard 1.00
+    Guava 1.01
+    Acorn_Squash 1.01
+    Parsley 1.01
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T11:46:50Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T11:46:50Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T11:46:50Z INFO  blarun] Submission from user: ayoubkassi has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:46:50Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/abdelmajidhafidi/main.php"
+[2024-03-10T11:46:50Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:46:50Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/abdelmajidhafidi/main.php" to "/tmp/.tmpo3SlTe/sol.php"
+[2024-03-10T11:46:50Z DEBUG blarun] The current started process has pid: 323702
+[2024-03-10T11:46:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:50Z DEBUG blarun] Correctness execution finished in: 87.118075ms
+[2024-03-10T11:46:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:50Z DEBUG blarun] Comparing output "/tmp/.tmpo3SlTe/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:50Z DEBUG blarun] The current started process has pid: 323703
+[2024-03-10T11:46:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:50Z DEBUG blarun] Correctness execution finished in: 84.123425ms
+[2024-03-10T11:46:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:46:50Z DEBUG blarun] Comparing output "/tmp/.tmpo3SlTe/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:46:50Z INFO  blarun] Solution comparison failed, output for the solution is: Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.1
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+     expected output is Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.10
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+    
+[2024-03-10T11:46:50Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T11:46:50Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T11:46:50Z INFO  blarun] Submission from user: abdelmajidhafidi has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:46:50Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/gitRedDev/Main.java"
+[2024-03-10T11:46:51Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpC1GJJI/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:51Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:46:51Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/gitRedDev/Main.java" to "/tmp/.tmpxZdlgn/Main.java"
+[2024-03-10T11:46:51Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:46:51Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpxZdlgn/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:51Z DEBUG blarun] The current started process has pid: 323768
+[2024-03-10T11:46:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:52Z DEBUG blarun] Correctness execution finished in: 364.927756ms
+[2024-03-10T11:46:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:52Z DEBUG blarun] Comparing output "/tmp/.tmpxZdlgn/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:52Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.46
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T11:46:52Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T11:46:52Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T11:46:52Z INFO  blarun] Submission from user: gitRedDev has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:46:52Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/AbdelaliELMANTAGUI/Main.java"
+[2024-03-10T11:46:52Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmptnuJyS/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:52Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:46:52Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/AbdelaliELMANTAGUI/Main.java" to "/tmp/.tmpCEZEMd/Main.java"
+[2024-03-10T11:46:52Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:46:53Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpCEZEMd/Main.java" with exit code: exit status: 0
+[2024-03-10T11:46:53Z DEBUG blarun] The current started process has pid: 323881
+[2024-03-10T11:46:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:53Z DEBUG blarun] Correctness execution finished in: 249.673603ms
+[2024-03-10T11:46:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:53Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:46:53Z DEBUG blarun] The current started process has pid: 323915
+[2024-03-10T11:46:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:53Z DEBUG blarun] Correctness execution finished in: 258.628422ms
+[2024-03-10T11:46:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:46:53Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:46:53Z DEBUG blarun] The current started process has pid: 323949
+[2024-03-10T11:46:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:54Z DEBUG blarun] Correctness execution finished in: 276.30718ms
+[2024-03-10T11:46:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:46:54Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:46:54Z DEBUG blarun] The current started process has pid: 323983
+[2024-03-10T11:46:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:54Z DEBUG blarun] Correctness execution finished in: 262.833102ms
+[2024-03-10T11:46:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:46:54Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:46:54Z DEBUG blarun] The current started process has pid: 324017
+[2024-03-10T11:46:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:54Z DEBUG blarun] Correctness execution finished in: 255.181751ms
+[2024-03-10T11:46:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:46:54Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:46:54Z DEBUG blarun] The current started process has pid: 324051
+[2024-03-10T11:46:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:55Z DEBUG blarun] Correctness execution finished in: 261.63484ms
+[2024-03-10T11:46:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:46:55Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:46:55Z DEBUG blarun] The current started process has pid: 324084
+[2024-03-10T11:46:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:55Z DEBUG blarun] Correctness execution finished in: 240.838317ms
+[2024-03-10T11:46:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:46:55Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:46:55Z DEBUG blarun] The current started process has pid: 324118
+[2024-03-10T11:46:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:55Z DEBUG blarun] Correctness execution finished in: 232.366307ms
+[2024-03-10T11:46:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:46:55Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:46:55Z DEBUG blarun] The current started process has pid: 324152
+[2024-03-10T11:46:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:55Z DEBUG blarun] Correctness execution finished in: 263.005497ms
+[2024-03-10T11:46:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:46:55Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:46:55Z DEBUG blarun] The current started process has pid: 324186
+[2024-03-10T11:46:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:46:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:46:56Z DEBUG blarun] Correctness execution finished in: 227.831688ms
+[2024-03-10T11:46:56Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:46:56Z DEBUG blarun] Comparing output "/tmp/.tmpCEZEMd/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:46:56Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T11:46:56Z INFO  blarun] Dropping the file cache
+[2024-03-10T11:46:56Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmptnuJyS/input.txt"
+[2024-03-10T11:46:56Z DEBUG blarun] Starting execution run #0
+[2024-03-10T11:46:56Z DEBUG blarun] The current started process has pid: 324223
+[2024-03-10T11:46:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
+	at java.base/java.util.Arrays.copyOfRange(Arrays.java:3822)
+	at java.base/java.lang.StringLatin1.newString(StringLatin1.java:769)
+	at java.base/java.lang.String.substring(String.java:2714)
+	at java.base/java.lang.String.split(String.java:3127)
+	at java.base/java.lang.String.split(String.java:3201)
+	at Main.lambda$solve$0(Main.java:27)
+	at Main$$Lambda$2/0x00007f91a8000a08.apply(Unknown Source)
+	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
+	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
+	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
+	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
+	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
+	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
+	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
+	at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:667)
+	at Main.solve(Main.java:28)
+	at Main.main(Main.java:18)
+[2024-03-10T11:47:45Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T11:47:45Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/AbdelaliELMANTAGUI/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "AbdelaliELMANTAGUI" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T11:47:45Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Utchiha555/main.c"
+[2024-03-10T11:47:45Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpRyug8i/sol" with exit code: exit status: 0
+[2024-03-10T11:47:45Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:47:45Z DEBUG blarun] The current started process has pid: 324281
+[2024-03-10T11:47:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:45Z DEBUG blarun] Correctness execution finished in: 59.790046ms
+[2024-03-10T11:47:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:47:45Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:47:45Z DEBUG blarun] The current started process has pid: 324282
+[2024-03-10T11:47:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:45Z DEBUG blarun] Correctness execution finished in: 60.217441ms
+[2024-03-10T11:47:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:47:45Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:47:45Z DEBUG blarun] The current started process has pid: 324283
+[2024-03-10T11:47:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:45Z DEBUG blarun] Correctness execution finished in: 60.114843ms
+[2024-03-10T11:47:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:47:45Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:47:45Z DEBUG blarun] The current started process has pid: 324284
+[2024-03-10T11:47:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:45Z DEBUG blarun] Correctness execution finished in: 59.83452ms
+[2024-03-10T11:47:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:47:45Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:47:45Z DEBUG blarun] The current started process has pid: 324285
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 70.94311ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324286
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 62.692615ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324287
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 59.885764ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324288
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 60.90246ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324289
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 61.001411ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324290
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:47:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:47:46Z DEBUG blarun] Correctness execution finished in: 59.638026ms
+[2024-03-10T11:47:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:47:46Z DEBUG blarun] Comparing output "/tmp/.tmp2QGAPf/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:47:46Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T11:47:46Z INFO  blarun] Dropping the file cache
+[2024-03-10T11:47:46Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpRyug8i/input.txt"
+[2024-03-10T11:47:46Z DEBUG blarun] Starting execution #0
+[2024-03-10T11:47:46Z DEBUG blarun] The current started process has pid: 324293
+[2024-03-10T11:47:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:46Z DEBUG blarun] Child process timed out
+[2024-03-10T11:57:46Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T11:57:46Z INFO  blarun] Submission from user: Utchiha555 has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:57:46Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/joel071/Main.java"
+[2024-03-10T11:57:47Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpBNtpkV/Main.java" with exit code: exit status: 0
+[2024-03-10T11:57:47Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:57:47Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/joel071/Main.java" to "/tmp/.tmpHiOXVQ/Main.java"
+[2024-03-10T11:57:47Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:57:48Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpHiOXVQ/Main.java" with exit code: exit status: 0
+[2024-03-10T11:57:48Z DEBUG blarun] The current started process has pid: 324370
+[2024-03-10T11:57:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "main" java.nio.file.NoSuchFileException: output.txt
+	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
+	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
+	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
+	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
+	at java.base/java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:484)
+	at java.base/java.nio.file.Files.newOutputStream(Files.java:228)
+	at java.base/java.nio.file.Files.write(Files.java:3512)
+	at Main.writeToFile(Main.java:88)
+	at Main.main(Main.java:73)
+[2024-03-10T11:57:48Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T11:57:48Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/joel071/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "joel071" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T11:57:48Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mohsine1999/Main.java"
+[2024-03-10T11:57:49Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpk5bqGR/Main.java" with exit code: exit status: 0
+[2024-03-10T11:57:49Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:57:49Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/mohsine1999/Main.java" to "/tmp/.tmprmucsW/Main.java"
+[2024-03-10T11:57:49Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T11:57:50Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmprmucsW/Main.java" with exit code: exit status: 0
+[2024-03-10T11:57:50Z DEBUG blarun] The current started process has pid: 324473
+[2024-03-10T11:57:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:50Z DEBUG blarun] Correctness execution finished in: 286.44211ms
+[2024-03-10T11:57:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:57:50Z DEBUG blarun] Comparing output "/tmp/.tmprmucsW/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:57:50Z INFO  blarun] Solution comparison failed, output for the solution is: Arfoud 763.49
+    Kiwi 1.00
+    Oregano 1.12
+    Plantain 1.12
+    Raspberry 1.17
+    Carrot 1.26
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T11:57:50Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T11:57:50Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T11:57:50Z INFO  blarun] Submission from user: mohsine1999 has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T11:57:50Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/j-mounim/index.js"
+[2024-03-10T11:57:50Z INFO  blarun] Starting correctness checks
+[2024-03-10T11:57:50Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/j-mounim/index.js" to "/tmp/.tmpNVhbKi/main.js"
+[2024-03-10T11:57:50Z DEBUG blarun] The current started process has pid: 324497
+[2024-03-10T11:57:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:51Z DEBUG blarun] Correctness execution finished in: 700.891078ms
+[2024-03-10T11:57:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:57:51Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T11:57:51Z DEBUG blarun] The current started process has pid: 324524
+[2024-03-10T11:57:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:51Z DEBUG blarun] Correctness execution finished in: 367.272277ms
+[2024-03-10T11:57:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:57:51Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T11:57:51Z DEBUG blarun] The current started process has pid: 324551
+[2024-03-10T11:57:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:51Z DEBUG blarun] Correctness execution finished in: 352.80674ms
+[2024-03-10T11:57:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:57:51Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T11:57:51Z DEBUG blarun] The current started process has pid: 324578
+[2024-03-10T11:57:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:52Z DEBUG blarun] Correctness execution finished in: 373.997867ms
+[2024-03-10T11:57:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:57:52Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T11:57:52Z DEBUG blarun] The current started process has pid: 324605
+[2024-03-10T11:57:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:52Z DEBUG blarun] Correctness execution finished in: 365.245808ms
+[2024-03-10T11:57:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:57:52Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T11:57:52Z DEBUG blarun] The current started process has pid: 324632
+[2024-03-10T11:57:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:52Z DEBUG blarun] Correctness execution finished in: 362.237041ms
+[2024-03-10T11:57:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:57:52Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T11:57:52Z DEBUG blarun] The current started process has pid: 324659
+[2024-03-10T11:57:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:53Z DEBUG blarun] Correctness execution finished in: 367.560572ms
+[2024-03-10T11:57:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:57:53Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T11:57:53Z DEBUG blarun] The current started process has pid: 324686
+[2024-03-10T11:57:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:53Z DEBUG blarun] Correctness execution finished in: 361.553328ms
+[2024-03-10T11:57:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:57:53Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T11:57:53Z DEBUG blarun] The current started process has pid: 324713
+[2024-03-10T11:57:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:54Z DEBUG blarun] Correctness execution finished in: 371.606744ms
+[2024-03-10T11:57:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:57:54Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T11:57:54Z DEBUG blarun] The current started process has pid: 324740
+[2024-03-10T11:57:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:57:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:57:54Z DEBUG blarun] Correctness execution finished in: 356.300636ms
+[2024-03-10T11:57:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:57:54Z DEBUG blarun] Comparing output "/tmp/.tmpNVhbKi/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T11:57:54Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T11:57:54Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp8pdJvQ/input.txt"
+[2024-03-10T11:57:54Z DEBUG blarun] The current started process has pid: 324767
+[2024-03-10T11:57:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T11:59:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T11:59:18Z DEBUG blarun] Execution #0 finished in: 84.285896357s
+[2024-03-10T11:59:18Z DEBUG blarun] Comparing output "/tmp/.tmp8pdJvQ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T11:59:18Z DEBUG blarun] The current started process has pid: 324794
+[2024-03-10T11:59:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:00:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:00:43Z DEBUG blarun] Execution #1 finished in: 84.509444509s
+[2024-03-10T12:00:43Z DEBUG blarun] Comparing output "/tmp/.tmp8pdJvQ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:00:43Z DEBUG blarun] The current started process has pid: 324822
+[2024-03-10T12:00:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:02:07Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:02:07Z DEBUG blarun] Execution #2 finished in: 84.456890927s
+[2024-03-10T12:02:07Z DEBUG blarun] Comparing output "/tmp/.tmp8pdJvQ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:02:07Z DEBUG blarun] The current started process has pid: 324858
+[2024-03-10T12:02:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:03:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:03:31Z DEBUG blarun] Execution #3 finished in: 83.616362978s
+[2024-03-10T12:03:31Z DEBUG blarun] Comparing output "/tmp/.tmp8pdJvQ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:03:31Z DEBUG blarun] The current started process has pid: 324887
+[2024-03-10T12:03:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:54Z DEBUG blarun] Execution #4 finished in: 83.340030774s
+[2024-03-10T12:04:54Z DEBUG blarun] Comparing output "/tmp/.tmp8pdJvQ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:04:54Z INFO  blarun] Submission from user: j-mounim has finished with verdict: Ac and with an AVG execution time of: 84.119716754s and MED of 84.285896357s
+[2024-03-10T12:04:54Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/YoussefAdebouz/main.cpp"
+/home/maxheap/blanat/submissions/YoussefAdebouz/main.cpp: In function ‘std::string find_cheapest_city(std::map<std::__cxx11::basic_string<char>, City>&)’:
+/home/maxheap/blanat/submissions/YoussefAdebouz/main.cpp:46:30: error: ‘numeric_limits’ was not declared in this scope
+   46 |     double min_total_price = numeric_limits<double>::max();
+      |                              ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/YoussefAdebouz/main.cpp:46:45: error: expected primary-expression before ‘double’
+   46 |     double min_total_price = numeric_limits<double>::max();
+      |                                             ^~~~~~
+[2024-03-10T12:04:55Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpPY41cM/sol" with exit code: exit status: 1
+[2024-03-10T12:04:55Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/YoussefAdebouz/main.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "YoussefAdebouz" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T12:04:55Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/nizarbenalla/Main.java"
+[2024-03-10T12:04:56Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmphluIDg/Main.java" with exit code: exit status: 0
+[2024-03-10T12:04:56Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:04:56Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/nizarbenalla/Main.java" to "/tmp/.tmpZgDfmK/Main.java"
+[2024-03-10T12:04:56Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:04:56Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpZgDfmK/Main.java" with exit code: exit status: 0
+[2024-03-10T12:04:56Z DEBUG blarun] The current started process has pid: 324982
+[2024-03-10T12:04:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:57Z DEBUG blarun] Correctness execution finished in: 327.83201ms
+[2024-03-10T12:04:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:04:57Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:04:57Z DEBUG blarun] The current started process has pid: 325023
+[2024-03-10T12:04:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:57Z DEBUG blarun] Correctness execution finished in: 263.69609ms
+[2024-03-10T12:04:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:04:57Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:04:57Z DEBUG blarun] The current started process has pid: 325064
+[2024-03-10T12:04:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:57Z DEBUG blarun] Correctness execution finished in: 295.644575ms
+[2024-03-10T12:04:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:04:57Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:04:57Z DEBUG blarun] The current started process has pid: 325105
+[2024-03-10T12:04:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:58Z DEBUG blarun] Correctness execution finished in: 333.69284ms
+[2024-03-10T12:04:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:04:58Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:04:58Z DEBUG blarun] The current started process has pid: 325146
+[2024-03-10T12:04:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:58Z DEBUG blarun] Correctness execution finished in: 366.367171ms
+[2024-03-10T12:04:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:04:58Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:04:58Z DEBUG blarun] The current started process has pid: 325187
+[2024-03-10T12:04:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:58Z DEBUG blarun] Correctness execution finished in: 306.727226ms
+[2024-03-10T12:04:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:04:58Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:04:58Z DEBUG blarun] The current started process has pid: 325228
+[2024-03-10T12:04:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:59Z DEBUG blarun] Correctness execution finished in: 302.540586ms
+[2024-03-10T12:04:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:04:59Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:04:59Z DEBUG blarun] The current started process has pid: 325269
+[2024-03-10T12:04:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:59Z DEBUG blarun] Correctness execution finished in: 313.319167ms
+[2024-03-10T12:04:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:04:59Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:04:59Z DEBUG blarun] The current started process has pid: 325310
+[2024-03-10T12:04:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:59Z DEBUG blarun] Correctness execution finished in: 302.360664ms
+[2024-03-10T12:04:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:04:59Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:04:59Z DEBUG blarun] The current started process has pid: 325351
+[2024-03-10T12:04:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:04:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:04:59Z DEBUG blarun] Correctness execution finished in: 314.485102ms
+[2024-03-10T12:04:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:04:59Z DEBUG blarun] Comparing output "/tmp/.tmpZgDfmK/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:04:59Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:04:59Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:05:01Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmphluIDg/input.txt"
+[2024-03-10T12:05:01Z DEBUG blarun] Starting execution run #0
+[2024-03-10T12:05:01Z DEBUG blarun] The current started process has pid: 325395
+[2024-03-10T12:05:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "pool-1-thread-1" java.lang.OutOfMemoryError: Java heap space
+	at java.base/java.lang.String.<init>(String.java:536)
+	at java.base/java.lang.String.<init>(String.java:1387)
+	at Main.run(Main.java:51)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base/java.lang.Thread.run(Thread.java:840)
+Exception in thread "pool-1-thread-2" java.lang.OutOfMemoryError: Java heap space
+	at java.base/java.lang.String.<init>(String.java:536)
+	at java.base/java.lang.String.<init>(String.java:1387)
+	at Main.run(Main.java:51)
+	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
+	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
+	at java.base/java.lang.Thread.run(Thread.java:840)
+Exception in thread "pool-1-thread-3" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-4" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-5" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-6" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-7" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-8" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-9" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-10" java.lang.OutOfMemoryError: Java heap space
+Exception in thread "pool-1-thread-11" java.lang.OutOfMemoryError: Java heap space
+[2024-03-10T12:06:35Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:35Z DEBUG blarun] Execution #0 finished in: 93.954536371s
+[2024-03-10T12:06:35Z DEBUG blarun] Computing verdict using "/tmp/.tmphluIDg/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:06:35Z DEBUG blarun] Comparing output "/tmp/.tmphluIDg/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:06:35Z INFO  blarun] Solution comparison failed, output for the solution is: 
+     expected output is Drarga 499408537.35
+    Acorn_Squash 1.00
+    Apple 1.00
+    Apricot 1.00
+    Artichoke 1.00
+    Asparagus 1.00
+    
+[2024-03-10T12:06:35Z DEBUG blarun] Submission is not correct, aborting further runs
+[2024-03-10T12:06:35Z INFO  blarun] Submission from user: nizarbenalla has finished with verdict: Wa and with an AVG execution time of: 93.954536371s and MED of 93.954536371s
+[2024-03-10T12:06:35Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/lhousaine/index.js"
+[2024-03-10T12:06:35Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:06:35Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/lhousaine/index.js" to "/tmp/.tmpVB7OYy/main.js"
+[2024-03-10T12:06:35Z DEBUG blarun] The current started process has pid: 325465
+[2024-03-10T12:06:35Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:36Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:36Z DEBUG blarun] Correctness execution finished in: 599.416924ms
+[2024-03-10T12:06:36Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:06:36Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:06:36Z DEBUG blarun] The current started process has pid: 325492
+[2024-03-10T12:06:36Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:36Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:36Z DEBUG blarun] Correctness execution finished in: 347.653515ms
+[2024-03-10T12:06:36Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:06:36Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:06:36Z DEBUG blarun] The current started process has pid: 325519
+[2024-03-10T12:06:36Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:36Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:36Z DEBUG blarun] Correctness execution finished in: 368.226653ms
+[2024-03-10T12:06:36Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:06:36Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:06:36Z DEBUG blarun] The current started process has pid: 325546
+[2024-03-10T12:06:36Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:37Z DEBUG blarun] Correctness execution finished in: 351.811311ms
+[2024-03-10T12:06:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:06:37Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:06:37Z DEBUG blarun] The current started process has pid: 325573
+[2024-03-10T12:06:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:37Z DEBUG blarun] Correctness execution finished in: 356.222408ms
+[2024-03-10T12:06:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:06:37Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:06:37Z DEBUG blarun] The current started process has pid: 325600
+[2024-03-10T12:06:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:37Z DEBUG blarun] Correctness execution finished in: 356.090344ms
+[2024-03-10T12:06:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:06:37Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:06:37Z DEBUG blarun] The current started process has pid: 325627
+[2024-03-10T12:06:38Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:38Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:38Z DEBUG blarun] Correctness execution finished in: 359.186853ms
+[2024-03-10T12:06:38Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:06:38Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:06:38Z DEBUG blarun] The current started process has pid: 325654
+[2024-03-10T12:06:38Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:38Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:38Z DEBUG blarun] Correctness execution finished in: 348.514809ms
+[2024-03-10T12:06:38Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:06:38Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:06:38Z DEBUG blarun] The current started process has pid: 325681
+[2024-03-10T12:06:38Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:39Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:39Z DEBUG blarun] Correctness execution finished in: 354.64149ms
+[2024-03-10T12:06:39Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:06:39Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:06:39Z DEBUG blarun] The current started process has pid: 325708
+[2024-03-10T12:06:39Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:06:39Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:06:39Z DEBUG blarun] Correctness execution finished in: 346.386229ms
+[2024-03-10T12:06:39Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:06:39Z DEBUG blarun] Comparing output "/tmp/.tmpVB7OYy/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:06:39Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:06:39Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpoQBK2S/input.txt"
+[2024-03-10T12:06:39Z DEBUG blarun] The current started process has pid: 325735
+[2024-03-10T12:06:39Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:08:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:08:28Z DEBUG blarun] Execution #0 finished in: 108.640222596s
+[2024-03-10T12:08:28Z DEBUG blarun] Comparing output "/tmp/.tmpoQBK2S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:08:28Z DEBUG blarun] The current started process has pid: 325762
+[2024-03-10T12:08:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:10:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:10:19Z DEBUG blarun] Execution #1 finished in: 111.0783771s
+[2024-03-10T12:10:19Z DEBUG blarun] Comparing output "/tmp/.tmpoQBK2S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:10:19Z DEBUG blarun] The current started process has pid: 325823
+[2024-03-10T12:10:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:12:07Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:12:07Z DEBUG blarun] Execution #2 finished in: 108.361847886s
+[2024-03-10T12:12:07Z DEBUG blarun] Comparing output "/tmp/.tmpoQBK2S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:12:07Z DEBUG blarun] The current started process has pid: 325859
+[2024-03-10T12:12:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:13:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:13:55Z DEBUG blarun] Execution #3 finished in: 108.031349764s
+[2024-03-10T12:13:55Z DEBUG blarun] Comparing output "/tmp/.tmpoQBK2S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:13:55Z DEBUG blarun] The current started process has pid: 325887
+[2024-03-10T12:13:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:45Z DEBUG blarun] Execution #4 finished in: 109.460486177s
+[2024-03-10T12:15:45Z DEBUG blarun] Comparing output "/tmp/.tmpoQBK2S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:15:45Z INFO  blarun] Submission from user: lhousaine has finished with verdict: Ac and with an AVG execution time of: 108.820852219s and MED of 108.640222596s
+[2024-03-10T12:15:45Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/yabad-codes/main.c"
+/home/maxheap/blanat/submissions/yabad-codes/main.c: In function ‘void insert(hashMap*, const char*, const char*, double)’:
+/home/maxheap/blanat/submissions/yabad-codes/main.c:134:30: error: expected unqualified-id before ‘new’
+  134 |                 productPair *new = (productPair *)malloc(sizeof(productPair));
+      |                              ^~~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:135:20: error: expected type-specifier before ‘->’ token
+  135 |                 new->price = price;
+      |                    ^~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:136:20: error: expected type-specifier before ‘->’ token
+  136 |                 new->product = strdup(product);
+      |                    ^~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:137:58: error: expected type-specifier before ‘;’ token
+  137 |                 node->products[node->product_count] = new;
+      |                                                          ^
+/home/maxheap/blanat/submissions/yabad-codes/main.c: In function ‘int main()’:
+/home/maxheap/blanat/submissions/yabad-codes/main.c:323:62: error: expected unqualified-id before ‘new’
+  323 |                                                 productPair *new = (productPair *)malloc(sizeof(productPair));
+      |                                                              ^~~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:324:52: error: expected type-specifier before ‘->’ token
+  324 |                                                 new->price = node->products[k]->price;
+      |                                                    ^~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:325:52: error: expected type-specifier before ‘->’ token
+  325 |                                                 new->product = strdup(node->products[k]->product);
+      |                                                    ^~
+/home/maxheap/blanat/submissions/yabad-codes/main.c:326:96: error: expected type-specifier before ‘;’ token
+  326 |                                                 current->products[current->product_count] = new;
+      |                                                                                                ^
+[2024-03-10T12:15:45Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpStF8dj/sol" with exit code: exit status: 1
+[2024-03-10T12:15:45Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/yabad-codes/main.c", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "yabad-codes" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T12:15:45Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/aarrasseayoub01/solution.rs"
+[2024-03-10T12:15:45Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/aarrasseayoub01/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "aarrasseayoub01" } with error: No such file or directory (os error 2)
+[2024-03-10T12:15:45Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ibrataha8/main.cpp"
+[2024-03-10T12:15:47Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpBOGHUY/sol" with exit code: exit status: 0
+[2024-03-10T12:15:47Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 325922
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 31.038934ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 325947
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.480469ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 325972
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.134367ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 325997
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.139223ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326022
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.275822ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326047
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.16689ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326072
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.281994ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326097
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.276346ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326122
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.22063ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:15:47Z DEBUG blarun] The current started process has pid: 326147
+[2024-03-10T12:15:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:15:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:15:47Z DEBUG blarun] Correctness execution finished in: 7.112996ms
+[2024-03-10T12:15:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:15:47Z DEBUG blarun] Comparing output "/tmp/.tmpXBGJiu/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:15:47Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:15:47Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:15:49Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpBOGHUY/input.txt"
+[2024-03-10T12:15:49Z DEBUG blarun] Starting execution #0
+[2024-03-10T12:15:49Z DEBUG blarun] The current started process has pid: 326174
+[2024-03-10T12:15:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:08Z DEBUG blarun] Execution #0 finished in: 79.028452549s
+[2024-03-10T12:17:08Z DEBUG blarun] Computing verdict using "/tmp/.tmpBOGHUY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:08Z DEBUG blarun] Comparing output "/tmp/.tmpBOGHUY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:08Z DEBUG blarun] Starting execution #1
+[2024-03-10T12:17:08Z DEBUG blarun] The current started process has pid: 326204
+[2024-03-10T12:17:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:27Z DEBUG blarun] Execution #1 finished in: 19.568979331s
+[2024-03-10T12:17:27Z DEBUG blarun] Computing verdict using "/tmp/.tmpBOGHUY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:27Z DEBUG blarun] Comparing output "/tmp/.tmpBOGHUY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:27Z DEBUG blarun] Starting execution #2
+[2024-03-10T12:17:27Z DEBUG blarun] The current started process has pid: 326229
+[2024-03-10T12:17:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:36Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:36Z DEBUG blarun] Execution #2 finished in: 8.510478359s
+[2024-03-10T12:17:36Z DEBUG blarun] Computing verdict using "/tmp/.tmpBOGHUY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:36Z DEBUG blarun] Comparing output "/tmp/.tmpBOGHUY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:36Z DEBUG blarun] Starting execution #3
+[2024-03-10T12:17:36Z DEBUG blarun] The current started process has pid: 326256
+[2024-03-10T12:17:36Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:44Z DEBUG blarun] Execution #3 finished in: 8.515358802s
+[2024-03-10T12:17:44Z DEBUG blarun] Computing verdict using "/tmp/.tmpBOGHUY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:44Z DEBUG blarun] Comparing output "/tmp/.tmpBOGHUY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:44Z DEBUG blarun] Starting execution #4
+[2024-03-10T12:17:44Z DEBUG blarun] The current started process has pid: 326281
+[2024-03-10T12:17:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:53Z DEBUG blarun] Execution #4 finished in: 8.504455987s
+[2024-03-10T12:17:53Z DEBUG blarun] Computing verdict using "/tmp/.tmpBOGHUY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:53Z DEBUG blarun] Comparing output "/tmp/.tmpBOGHUY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:17:53Z INFO  blarun] Submission from user: ibrataha8 has finished with verdict: Ac and with an AVG execution time of: 12.198272164s and MED of 8.515358802s
+[2024-03-10T12:17:53Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ttlgeek/Main.java"
+[2024-03-10T12:17:54Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp9LduN9/Main.java" with exit code: exit status: 0
+[2024-03-10T12:17:54Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:17:54Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ttlgeek/Main.java" to "/tmp/.tmpUUjBmI/Main.java"
+[2024-03-10T12:17:54Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:17:55Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpUUjBmI/Main.java" with exit code: exit status: 0
+[2024-03-10T12:17:55Z DEBUG blarun] The current started process has pid: 326372
+[2024-03-10T12:17:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:55Z DEBUG blarun] Correctness execution finished in: 257.0839ms
+[2024-03-10T12:17:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:55Z DEBUG blarun] Comparing output "/tmp/.tmpUUjBmI/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:55Z INFO  blarun] Solution comparison failed, output for the solution is: Al_Hoceima 46691.12
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T12:17:55Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:17:55Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:17:55Z INFO  blarun] Submission from user: ttlgeek has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:17:55Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/hamzanaciri99/Main.java"
+[2024-03-10T12:17:56Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpimyPPX/Main.java" with exit code: exit status: 0
+[2024-03-10T12:17:56Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:17:56Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/hamzanaciri99/Main.java" to "/tmp/.tmpuXTi7X/Main.java"
+[2024-03-10T12:17:56Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:17:56Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpuXTi7X/Main.java" with exit code: exit status: 0
+[2024-03-10T12:17:56Z DEBUG blarun] The current started process has pid: 326459
+[2024-03-10T12:17:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:57Z DEBUG blarun] Correctness execution finished in: 344.72709ms
+[2024-03-10T12:17:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:57Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:57Z DEBUG blarun] The current started process has pid: 326506
+[2024-03-10T12:17:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:57Z DEBUG blarun] Correctness execution finished in: 633.759336ms
+[2024-03-10T12:17:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:17:57Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:17:57Z DEBUG blarun] The current started process has pid: 326553
+[2024-03-10T12:17:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:58Z DEBUG blarun] Correctness execution finished in: 541.371277ms
+[2024-03-10T12:17:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:17:58Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:17:58Z DEBUG blarun] The current started process has pid: 326600
+[2024-03-10T12:17:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:58Z DEBUG blarun] Correctness execution finished in: 356.841416ms
+[2024-03-10T12:17:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:17:58Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:17:58Z DEBUG blarun] The current started process has pid: 326647
+[2024-03-10T12:17:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:59Z DEBUG blarun] Correctness execution finished in: 341.042236ms
+[2024-03-10T12:17:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:17:59Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:17:59Z DEBUG blarun] The current started process has pid: 326694
+[2024-03-10T12:17:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:59Z DEBUG blarun] Correctness execution finished in: 339.27898ms
+[2024-03-10T12:17:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:17:59Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:17:59Z DEBUG blarun] The current started process has pid: 326741
+[2024-03-10T12:17:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:59Z DEBUG blarun] Correctness execution finished in: 316.48254ms
+[2024-03-10T12:17:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:17:59Z DEBUG blarun] Comparing output "/tmp/.tmpuXTi7X/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:17:59Z INFO  blarun] Solution comparison failed, output for the solution is: Khouribga 45044.18
+    Currant 1.00
+    Guava 1.22
+    Artichoke 1.26
+    Spinach 1.27
+    Passion_Fruit 1.41
+    
+     expected output is Khouribga 45044.18
+    Currant 1.00
+    Pumpkin 1.17
+    Guava 1.22
+    Artichoke 1.26
+    Spinach 1.27
+    
+    
+[2024-03-10T12:17:59Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:17:59Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:17:59Z INFO  blarun] Submission from user: hamzanaciri99 has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:17:59Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/essmehdi/solution.rs"
+[2024-03-10T12:17:59Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/essmehdi/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "essmehdi" } with error: No such file or directory (os error 2)
+[2024-03-10T12:17:59Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/same-ou/solution.py"
+[2024-03-10T12:17:59Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:17:59Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/same-ou/solution.py" to "/tmp/.tmputGpDo/main.py"
+[2024-03-10T12:17:59Z DEBUG blarun] The current started process has pid: 326789
+[2024-03-10T12:17:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:17:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:17:59Z DEBUG blarun] Correctness execution finished in: 181.24931ms
+[2024-03-10T12:17:59Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:59Z DEBUG blarun] Comparing output "/tmp/.tmputGpDo/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:17:59Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45536.13
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T12:17:59Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:17:59Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:17:59Z INFO  blarun] Submission from user: same-ou has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:17:59Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/lmongol/main.c"
+/home/maxheap/blanat/submissions/lmongol/main.c:26:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   26 |     "Apple", "Banana", "Orange", "Strawberry", "Grapes",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:26:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   26 |     "Apple", "Banana", "Orange", "Strawberry", "Grapes",
+      |              ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:26:24: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   26 |     "Apple", "Banana", "Orange", "Strawberry", "Grapes",
+      |                        ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:26:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   26 |     "Apple", "Banana", "Orange", "Strawberry", "Grapes",
+      |                                  ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:26:48: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   26 |     "Apple", "Banana", "Orange", "Strawberry", "Grapes",
+      |                                                ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:27:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   27 |     "Watermelon", "Pineapple", "Mango", "Kiwi", "Peach",
+      |     ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:27:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   27 |     "Watermelon", "Pineapple", "Mango", "Kiwi", "Peach",
+      |                   ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:27:32: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   27 |     "Watermelon", "Pineapple", "Mango", "Kiwi", "Peach",
+      |                                ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:27:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   27 |     "Watermelon", "Pineapple", "Mango", "Kiwi", "Peach",
+      |                                         ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:27:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   27 |     "Watermelon", "Pineapple", "Mango", "Kiwi", "Peach",
+      |                                                 ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:28:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   28 |     "Plum", "Cherry", "Pear", "Blueberry", "Raspberry",
+      |     ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:28:13: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   28 |     "Plum", "Cherry", "Pear", "Blueberry", "Raspberry",
+      |             ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:28:23: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   28 |     "Plum", "Cherry", "Pear", "Blueberry", "Raspberry",
+      |                       ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:28:31: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   28 |     "Plum", "Cherry", "Pear", "Blueberry", "Raspberry",
+      |                               ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:28:44: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   28 |     "Plum", "Cherry", "Pear", "Blueberry", "Raspberry",
+      |                                            ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:29:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   29 |     "Blackberry", "Cantaloupe", "Honeydew", "Coconut", "Pomegranate",
+      |     ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:29:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   29 |     "Blackberry", "Cantaloupe", "Honeydew", "Coconut", "Pomegranate",
+      |                   ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:29:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   29 |     "Blackberry", "Cantaloupe", "Honeydew", "Coconut", "Pomegranate",
+      |                                 ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:29:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   29 |     "Blackberry", "Cantaloupe", "Honeydew", "Coconut", "Pomegranate",
+      |                                             ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:29:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   29 |     "Blackberry", "Cantaloupe", "Honeydew", "Coconut", "Pomegranate",
+      |                                                        ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:30:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   30 |     "Lemon", "Lime", "Grapefruit", "Avocado", "Papaya",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:30:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   30 |     "Lemon", "Lime", "Grapefruit", "Avocado", "Papaya",
+      |              ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:30:22: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   30 |     "Lemon", "Lime", "Grapefruit", "Avocado", "Papaya",
+      |                      ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:30:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   30 |     "Lemon", "Lime", "Grapefruit", "Avocado", "Papaya",
+      |                                    ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:30:47: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   30 |     "Lemon", "Lime", "Grapefruit", "Avocado", "Papaya",
+      |                                               ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:31:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   31 |     "Guava", "Fig", "Passion_Fruit", "Apricot", "Nectarine",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:31:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   31 |     "Guava", "Fig", "Passion_Fruit", "Apricot", "Nectarine",
+      |              ^~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:31:21: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   31 |     "Guava", "Fig", "Passion_Fruit", "Apricot", "Nectarine",
+      |                     ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:31:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   31 |     "Guava", "Fig", "Passion_Fruit", "Apricot", "Nectarine",
+      |                                      ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:31:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   31 |     "Guava", "Fig", "Passion_Fruit", "Apricot", "Nectarine",
+      |                                                 ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:32:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   32 |     "Cucumber", "Carrot", "Broccoli", "Spinach", "Kale",
+      |     ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:32:17: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   32 |     "Cucumber", "Carrot", "Broccoli", "Spinach", "Kale",
+      |                 ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:32:27: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   32 |     "Cucumber", "Carrot", "Broccoli", "Spinach", "Kale",
+      |                           ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:32:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   32 |     "Cucumber", "Carrot", "Broccoli", "Spinach", "Kale",
+      |                                       ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:32:50: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   32 |     "Cucumber", "Carrot", "Broccoli", "Spinach", "Kale",
+      |                                                  ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:33:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   33 |     "Lettuce", "Tomato", "Bell_Pepper", "Zucchini", "Eggplant",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:33:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   33 |     "Lettuce", "Tomato", "Bell_Pepper", "Zucchini", "Eggplant",
+      |                ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:33:26: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   33 |     "Lettuce", "Tomato", "Bell_Pepper", "Zucchini", "Eggplant",
+      |                          ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:33:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   33 |     "Lettuce", "Tomato", "Bell_Pepper", "Zucchini", "Eggplant",
+      |                                         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:33:53: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   33 |     "Lettuce", "Tomato", "Bell_Pepper", "Zucchini", "Eggplant",
+      |                                                     ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:34:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   34 |     "Cabbage", "Cauliflower", "Brussels_Sprouts", "Radish", "Beet",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:34:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   34 |     "Cabbage", "Cauliflower", "Brussels_Sprouts", "Radish", "Beet",
+      |                ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:34:31: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   34 |     "Cabbage", "Cauliflower", "Brussels_Sprouts", "Radish", "Beet",
+      |                               ^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:34:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   34 |     "Cabbage", "Cauliflower", "Brussels_Sprouts", "Radish", "Beet",
+      |                                                   ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:34:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   34 |     "Cabbage", "Cauliflower", "Brussels_Sprouts", "Radish", "Beet",
+      |                                                             ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:35:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   35 |     "Asparagus", "Artichoke", "Green_Beans", "Peas", "Celery",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:35:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   35 |     "Asparagus", "Artichoke", "Green_Beans", "Peas", "Celery",
+      |                  ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:35:31: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   35 |     "Asparagus", "Artichoke", "Green_Beans", "Peas", "Celery",
+      |                               ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:35:46: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   35 |     "Asparagus", "Artichoke", "Green_Beans", "Peas", "Celery",
+      |                                              ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:35:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   35 |     "Asparagus", "Artichoke", "Green_Beans", "Peas", "Celery",
+      |                                                      ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:36:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   36 |     "Onion", "Garlic", "Potato", "Sweet_Potato", "Yam",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:36:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   36 |     "Onion", "Garlic", "Potato", "Sweet_Potato", "Yam",
+      |              ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:36:24: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   36 |     "Onion", "Garlic", "Potato", "Sweet_Potato", "Yam",
+      |                        ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:36:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   36 |     "Onion", "Garlic", "Potato", "Sweet_Potato", "Yam",
+      |                                  ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:36:50: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   36 |     "Onion", "Garlic", "Potato", "Sweet_Potato", "Yam",
+      |                                                  ^~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:37:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   37 |     "Butternut_Squash", "Acorn_Squash", "Pumpkin", "Cranberry", "Goji_Berry",
+      |     ^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:37:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   37 |     "Butternut_Squash", "Acorn_Squash", "Pumpkin", "Cranberry", "Goji_Berry",
+      |                         ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:37:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   37 |     "Butternut_Squash", "Acorn_Squash", "Pumpkin", "Cranberry", "Goji_Berry",
+      |                                         ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:37:52: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   37 |     "Butternut_Squash", "Acorn_Squash", "Pumpkin", "Cranberry", "Goji_Berry",
+      |                                                    ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:37:65: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   37 |     "Butternut_Squash", "Acorn_Squash", "Pumpkin", "Cranberry", "Goji_Berry",
+      |                                                                 ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:38:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   38 |     "Currant", "Date", "Clementine", "Cranberry", "Rhubarb",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:38:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   38 |     "Currant", "Date", "Clementine", "Cranberry", "Rhubarb",
+      |                ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:38:24: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   38 |     "Currant", "Date", "Clementine", "Cranberry", "Rhubarb",
+      |                        ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:38:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   38 |     "Currant", "Date", "Clementine", "Cranberry", "Rhubarb",
+      |                                      ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:38:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   38 |     "Currant", "Date", "Clementine", "Cranberry", "Rhubarb",
+      |                                                   ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:39:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   39 |     "Chard", "Collard_Greens", "Parsley", "Cilantro", "Mint",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:39:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   39 |     "Chard", "Collard_Greens", "Parsley", "Cilantro", "Mint",
+      |              ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:39:32: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   39 |     "Chard", "Collard_Greens", "Parsley", "Cilantro", "Mint",
+      |                                ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:39:43: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   39 |     "Chard", "Collard_Greens", "Parsley", "Cilantro", "Mint",
+      |                                           ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:39:55: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   39 |     "Chard", "Collard_Greens", "Parsley", "Cilantro", "Mint",
+      |                                                       ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |              ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:23: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |                       ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |                                   ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:43: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |                                           ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:40:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   40 |     "Basil", "Thyme", "Rosemary", "Sage", "Dill", "Oregano",
+      |                                                   ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:41:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   41 |     "Jackfruit", "Starfruit", "Persimmon", "Ginger", "Turnip",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:41:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   41 |     "Jackfruit", "Starfruit", "Persimmon", "Ginger", "Turnip",
+      |                  ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:41:31: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   41 |     "Jackfruit", "Starfruit", "Persimmon", "Ginger", "Turnip",
+      |                               ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:41:44: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   41 |     "Jackfruit", "Starfruit", "Persimmon", "Ginger", "Turnip",
+      |                                            ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:41:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   41 |     "Jackfruit", "Starfruit", "Persimmon", "Ginger", "Turnip",
+      |                                                      ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:42:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   42 |     "Jicama", "Kohlrabi", "Watercress", "Okra", "Artichoke",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:42:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   42 |     "Jicama", "Kohlrabi", "Watercress", "Okra", "Artichoke",
+      |               ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:42:27: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   42 |     "Jicama", "Kohlrabi", "Watercress", "Okra", "Artichoke",
+      |                           ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:42:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   42 |     "Jicama", "Kohlrabi", "Watercress", "Okra", "Artichoke",
+      |                                         ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:42:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   42 |     "Jicama", "Kohlrabi", "Watercress", "Okra", "Artichoke",
+      |                                                 ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:43:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   43 |     "Plantain", "Cactus_Pear", "Kiwano", "Squash_Blossom", "Dragon_Fruit",
+      |     ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:43:17: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   43 |     "Plantain", "Cactus_Pear", "Kiwano", "Squash_Blossom", "Dragon_Fruit",
+      |                 ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:43:32: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   43 |     "Plantain", "Cactus_Pear", "Kiwano", "Squash_Blossom", "Dragon_Fruit",
+      |                                ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:43:42: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   43 |     "Plantain", "Cactus_Pear", "Kiwano", "Squash_Blossom", "Dragon_Fruit",
+      |                                          ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:43:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   43 |     "Plantain", "Cactus_Pear", "Kiwano", "Squash_Blossom", "Dragon_Fruit",
+      |                                                            ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:44:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   44 |     "Parsnip", "Rutabaga", "Salsify", "Bok_Choy", "Endive"
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:44:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   44 |     "Parsnip", "Rutabaga", "Salsify", "Bok_Choy", "Endive"
+      |                ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:44:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   44 |     "Parsnip", "Rutabaga", "Salsify", "Bok_Choy", "Endive"
+      |                            ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:44:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   44 |     "Parsnip", "Rutabaga", "Salsify", "Bok_Choy", "Endive"
+      |                                       ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:44:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   44 |     "Parsnip", "Rutabaga", "Salsify", "Bok_Choy", "Endive"
+      |                                                   ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:50:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   50 |     "Casablanca", "Rabat", "Marrakech", "Fes", "Tangier",
+      |     ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:50:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   50 |     "Casablanca", "Rabat", "Marrakech", "Fes", "Tangier",
+      |                   ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:50:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   50 |     "Casablanca", "Rabat", "Marrakech", "Fes", "Tangier",
+      |                            ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:50:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   50 |     "Casablanca", "Rabat", "Marrakech", "Fes", "Tangier",
+      |                                         ^~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:50:48: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   50 |     "Casablanca", "Rabat", "Marrakech", "Fes", "Tangier",
+      |                                                ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:51:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   51 |     "Agadir", "Meknes", "Oujda", "Kenitra", "Tetouan",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:51:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   51 |     "Agadir", "Meknes", "Oujda", "Kenitra", "Tetouan",
+      |               ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:51:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   51 |     "Agadir", "Meknes", "Oujda", "Kenitra", "Tetouan",
+      |                         ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:51:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   51 |     "Agadir", "Meknes", "Oujda", "Kenitra", "Tetouan",
+      |                                  ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:51:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   51 |     "Agadir", "Meknes", "Oujda", "Kenitra", "Tetouan",
+      |                                             ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:52:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   52 |     "Safi", "El_Jadida", "Beni_Mellal", "Errachidia",
+      |     ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:52:13: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   52 |     "Safi", "El_Jadida", "Beni_Mellal", "Errachidia",
+      |             ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:52:26: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   52 |     "Safi", "El_Jadida", "Beni_Mellal", "Errachidia",
+      |                          ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:52:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   52 |     "Safi", "El_Jadida", "Beni_Mellal", "Errachidia",
+      |                                         ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:53:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   53 |     "Taza", "Essaouira", "Khouribga", "Guelmim",
+      |     ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:53:13: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   53 |     "Taza", "Essaouira", "Khouribga", "Guelmim",
+      |             ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:53:26: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   53 |     "Taza", "Essaouira", "Khouribga", "Guelmim",
+      |                          ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:53:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   53 |     "Taza", "Essaouira", "Khouribga", "Guelmim",
+      |                                       ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:54:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   54 |     "Jorf_El_Melha", "Laayoune", "Ksar_El_Kebir", "Sale", "Bir_Lehlou",
+      |     ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:54:22: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   54 |     "Jorf_El_Melha", "Laayoune", "Ksar_El_Kebir", "Sale", "Bir_Lehlou",
+      |                      ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:54:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   54 |     "Jorf_El_Melha", "Laayoune", "Ksar_El_Kebir", "Sale", "Bir_Lehlou",
+      |                                  ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:54:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   54 |     "Jorf_El_Melha", "Laayoune", "Ksar_El_Kebir", "Sale", "Bir_Lehlou",
+      |                                                   ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:54:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   54 |     "Jorf_El_Melha", "Laayoune", "Ksar_El_Kebir", "Sale", "Bir_Lehlou",
+      |                                                           ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:55:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   55 |     "Arfoud", "Temara", "Mohammedia", "Settat",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:55:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   55 |     "Arfoud", "Temara", "Mohammedia", "Settat",
+      |               ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:55:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   55 |     "Arfoud", "Temara", "Mohammedia", "Settat",
+      |                         ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:55:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   55 |     "Arfoud", "Temara", "Mohammedia", "Settat",
+      |                                       ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:56:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   56 |     "Béni_Mellal", "Nador", "Kalaat_MGouna",
+      |     ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:56:20: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   56 |     "Béni_Mellal", "Nador", "Kalaat_MGouna",
+      |                    ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:56:29: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   56 |     "Béni_Mellal", "Nador", "Kalaat_MGouna",
+      |                             ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:57:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   57 |     "Chichaoua", "Chefchaouen", "Al_Hoceima", "Taourirt",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:57:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   57 |     "Chichaoua", "Chefchaouen", "Al_Hoceima", "Taourirt",
+      |                  ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:57:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   57 |     "Chichaoua", "Chefchaouen", "Al_Hoceima", "Taourirt",
+      |                                 ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:57:47: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   57 |     "Chichaoua", "Chefchaouen", "Al_Hoceima", "Taourirt",
+      |                                               ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:58:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   58 |     "Taroudant", "Guelta_Zemmur", "Dakhla", "Laâyoune",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:58:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   58 |     "Taroudant", "Guelta_Zemmur", "Dakhla", "Laâyoune",
+      |                  ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:58:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   58 |     "Taroudant", "Guelta_Zemmur", "Dakhla", "Laâyoune",
+      |                                   ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:58:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   58 |     "Taroudant", "Guelta_Zemmur", "Dakhla", "Laâyoune",
+      |                                             ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:59:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   59 |     "Tiznit","Tinghir", "Ifrane", "Azrou", "Bab_Taza",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:59:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   59 |     "Tiznit","Tinghir", "Ifrane", "Azrou", "Bab_Taza",
+      |              ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:59:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   59 |     "Tiznit","Tinghir", "Ifrane", "Azrou", "Bab_Taza",
+      |                         ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:59:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   59 |     "Tiznit","Tinghir", "Ifrane", "Azrou", "Bab_Taza",
+      |                                   ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:59:44: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   59 |     "Tiznit","Tinghir", "Ifrane", "Azrou", "Bab_Taza",
+      |                                            ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:60:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   60 |     "Berrechid", "Sidi_Slimane", "Souk_Larbaa", "Tiflet", "Sidi_Bennour",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:60:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   60 |     "Berrechid", "Sidi_Slimane", "Souk_Larbaa", "Tiflet", "Sidi_Bennour",
+      |                  ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:60:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   60 |     "Berrechid", "Sidi_Slimane", "Souk_Larbaa", "Tiflet", "Sidi_Bennour",
+      |                                  ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:60:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   60 |     "Berrechid", "Sidi_Slimane", "Souk_Larbaa", "Tiflet", "Sidi_Bennour",
+      |                                                 ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:60:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   60 |     "Berrechid", "Sidi_Slimane", "Souk_Larbaa", "Tiflet", "Sidi_Bennour",
+      |                                                           ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:61:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   61 |     "Larache", "Tan-Tan", "Sidi_Ifni", "Goulmima",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:61:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   61 |     "Larache", "Tan-Tan", "Sidi_Ifni", "Goulmima",
+      |                ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:61:27: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   61 |     "Larache", "Tan-Tan", "Sidi_Ifni", "Goulmima",
+      |                           ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:61:40: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   61 |     "Larache", "Tan-Tan", "Sidi_Ifni", "Goulmima",
+      |                                        ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:62:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   62 |     "Midelt", "Figuig", "Azilal", "Jerada", "Youssoufia",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:62:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   62 |     "Midelt", "Figuig", "Azilal", "Jerada", "Youssoufia",
+      |               ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:62:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   62 |     "Midelt", "Figuig", "Azilal", "Jerada", "Youssoufia",
+      |                         ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:62:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   62 |     "Midelt", "Figuig", "Azilal", "Jerada", "Youssoufia",
+      |                                   ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:62:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   62 |     "Midelt", "Figuig", "Azilal", "Jerada", "Youssoufia",
+      |                                             ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:63:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   63 |     "Ksar_es_Seghir", "Tichka", "Ait_Melloul",
+      |     ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:63:23: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   63 |     "Ksar_es_Seghir", "Tichka", "Ait_Melloul",
+      |                       ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:63:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   63 |     "Ksar_es_Seghir", "Tichka", "Ait_Melloul",
+      |                                 ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:64:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   64 |     "Layoune", "Ben_guerir", "Ouarzazate", "Inezgane",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:64:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   64 |     "Layoune", "Ben_guerir", "Ouarzazate", "Inezgane",
+      |                ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:64:30: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   64 |     "Layoune", "Ben_guerir", "Ouarzazate", "Inezgane",
+      |                              ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:64:44: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   64 |     "Layoune", "Ben_guerir", "Ouarzazate", "Inezgane",
+      |                                            ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:65:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   65 |     "Oujda_Angad", "Sefrou", "Aourir",
+      |     ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:65:20: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   65 |     "Oujda_Angad", "Sefrou", "Aourir",
+      |                    ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:65:30: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   65 |     "Oujda_Angad", "Sefrou", "Aourir",
+      |                              ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:66:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   66 |     "Oulad_Teima", "Tichla", "Bni_Hadifa",
+      |     ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:66:20: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   66 |     "Oulad_Teima", "Tichla", "Bni_Hadifa",
+      |                    ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:66:30: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   66 |     "Oulad_Teima", "Tichla", "Bni_Hadifa",
+      |                              ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:67:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   67 |     "Fquih_Ben_Salah", "Guercif", "Bouarfa", "Demnate",
+      |     ^~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:67:24: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   67 |     "Fquih_Ben_Salah", "Guercif", "Bouarfa", "Demnate",
+      |                        ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:67:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   67 |     "Fquih_Ben_Salah", "Guercif", "Bouarfa", "Demnate",
+      |                                   ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:67:46: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   67 |     "Fquih_Ben_Salah", "Guercif", "Bouarfa", "Demnate",
+      |                                              ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:68:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   68 |     "Ahfir", "Berkane", "Akhfenir", "Boulemane",
+      |     ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:68:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   68 |     "Ahfir", "Berkane", "Akhfenir", "Boulemane",
+      |              ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:68:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   68 |     "Ahfir", "Berkane", "Akhfenir", "Boulemane",
+      |                         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:68:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   68 |     "Ahfir", "Berkane", "Akhfenir", "Boulemane",
+      |                                     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:69:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   69 |     "Khenifra", "Bir_Anzerane", "Assa", "Smara", "Boujdour",
+      |     ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:69:17: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   69 |     "Khenifra", "Bir_Anzerane", "Assa", "Smara", "Boujdour",
+      |                 ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:69:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   69 |     "Khenifra", "Bir_Anzerane", "Assa", "Smara", "Boujdour",
+      |                                 ^~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:69:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   69 |     "Khenifra", "Bir_Anzerane", "Assa", "Smara", "Boujdour",
+      |                                         ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:69:50: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   69 |     "Khenifra", "Bir_Anzerane", "Assa", "Smara", "Boujdour",
+      |                                                  ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:70:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   70 |     "Tarfaya", "Ouazzane", "Zagora", "had_soualem",
+      |     ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:70:16: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   70 |     "Tarfaya", "Ouazzane", "Zagora", "had_soualem",
+      |                ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:70:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   70 |     "Tarfaya", "Ouazzane", "Zagora", "had_soualem",
+      |                            ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:70:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   70 |     "Tarfaya", "Ouazzane", "Zagora", "had_soualem",
+      |                                      ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:71:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   71 |     "Saidia", "Bab_Berred", "Midar", "Moulay_Bousselham",
+      |     ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:71:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   71 |     "Saidia", "Bab_Berred", "Midar", "Moulay_Bousselham",
+      |               ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:71:29: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   71 |     "Saidia", "Bab_Berred", "Midar", "Moulay_Bousselham",
+      |                             ^~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:71:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   71 |     "Saidia", "Bab_Berred", "Midar", "Moulay_Bousselham",
+      |                                      ^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:72:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   72 |     "Khemisset", "Guerguerat", "Asilah", "Sidi_Bouzid", "Tafraout",
+      |     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:72:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   72 |     "Khemisset", "Guerguerat", "Asilah", "Sidi_Bouzid", "Tafraout",
+      |                  ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:72:32: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   72 |     "Khemisset", "Guerguerat", "Asilah", "Sidi_Bouzid", "Tafraout",
+      |                                ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:72:42: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   72 |     "Khemisset", "Guerguerat", "Asilah", "Sidi_Bouzid", "Tafraout",
+      |                                          ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:72:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   72 |     "Khemisset", "Guerguerat", "Asilah", "Sidi_Bouzid", "Tafraout",
+      |                                                         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:73:5: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   73 |     "Imzouren", "Zemamra", "Sidi_Kacem", "Drarga", "Skhirate"
+      |     ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:73:17: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   73 |     "Imzouren", "Zemamra", "Sidi_Kacem", "Drarga", "Skhirate"
+      |                 ^~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:73:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   73 |     "Imzouren", "Zemamra", "Sidi_Kacem", "Drarga", "Skhirate"
+      |                            ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:73:42: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   73 |     "Imzouren", "Zemamra", "Sidi_Kacem", "Drarga", "Skhirate"
+      |                                          ^~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:73:52: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+   73 |     "Imzouren", "Zemamra", "Sidi_Kacem", "Drarga", "Skhirate"
+      |                                                    ^~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘void init_pages()’:
+/home/maxheap/blanat/submissions/lmongol/main.c:154:25: error: invalid conversion from ‘void*’ to ‘float**’ [-fpermissive]
+  154 |         groc_cash = mmap(0, TCITIES * sizeof(float *), PROT_WRITE | PROT_READ
+      |                     ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                         |
+      |                         void*
+  155 |                         , MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:158:37: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+  158 |                 groc_cash[i] =  mmap(0,TGROCPERCITY * sizeof(float), PROT_WRITE | PROT_READ
+      |                                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                     |
+      |                                     void*
+  159 |                         , MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:161:21: error: invalid conversion from ‘void*’ to ‘double*’ [-fpermissive]
+  161 |         total = mmap(0, TCITIES * sizeof(double), PROT_WRITE | PROT_READ,
+      |                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                     |
+      |                     void*
+  162 |                         MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:164:30: error: invalid conversion from ‘void*’ to ‘char**’ [-fpermissive]
+  164 |         cities_baskets = mmap(0, TCITIES * sizeof(int *), PROT_WRITE | PROT_READ
+      |                          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                              |
+      |                              void*
+  165 |                         , MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:168:42: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
+  168 |                 cities_baskets[i] =  mmap(0,TGROCPERCITY * sizeof(int), PROT_WRITE | PROT_READ
+      |                                      ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                          |
+      |                                          void*
+  169 |                         , MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:171:36: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+  171 |         sorted_winner_basket = mmap(0, TGROCPERCITY * sizeof(float), PROT_WRITE | PROT_READ,
+      |                                ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                    |
+      |                                    void*
+  172 |                         MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:173:28: error: invalid conversion from ‘void*’ to ‘long long int*’ [-fpermissive]
+  173 |         cbaskets_idx = mmap(0, TGROCPERCITY * sizeof(int), PROT_WRITE | PROT_READ,
+      |                        ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                            |
+      |                            void*
+  174 |                         MAP_SHARED|MAP_ANONYMOUS, -1, 0 );
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘int search_city(char*)’:
+/home/maxheap/blanat/submissions/lmongol/main.c:181:13: warning: unused variable ‘len’ [-Wunused-variable]
+  181 |         int len = 0;
+      |             ^~~
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘void basket_compute(char*, int)’:
+/home/maxheap/blanat/submissions/lmongol/main.c:205:23: warning: unused variable ‘line’ [-Wunused-variable]
+  205 |                 char *line = page;
+      |                       ^~~~
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘void read_chunk(int)’:
+/home/maxheap/blanat/submissions/lmongol/main.c:234:51: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
+  234 |                         nlptr = strrchr(pages[id] + PAGE_SIZE - 40, '\n') + 1;
+      |                                                   ^
+/home/maxheap/blanat/submissions/lmongol/main.c:234:63: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
+  234 |                         nlptr = strrchr(pages[id] + PAGE_SIZE - 40, '\n') + 1;
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~^~~~
+/home/maxheap/blanat/submissions/lmongol/main.c:234:40: error: no matching function for call to ‘strrchr(void*, char)’
+  234 |                         nlptr = strrchr(pages[id] + PAGE_SIZE - 40, '\n') + 1;
+      |                                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from /home/maxheap/blanat/submissions/lmongol/main.c:8:
+/usr/include/string.h:266:1: note: candidate: ‘const char* strrchr(const char*, int)’ (near match)
+  266 | strrchr (const char *__s, int __c) __THROW
+      | ^~~~~~~
+/usr/include/string.h:266:1: note:   conversion of argument 1 would be ill-formed:
+/home/maxheap/blanat/submissions/lmongol/main.c:234:63: error: invalid conversion from ‘void*’ to ‘const char*’ [-fpermissive]
+  234 |                         nlptr = strrchr(pages[id] + PAGE_SIZE - 40, '\n') + 1;
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~^~~~
+      |                                                               |
+      |                                                               void*
+/usr/include/string.h:260:1: note: candidate: ‘char* strrchr(char*, int)’ (near match)
+  260 | strrchr (char *__s, int __c) __THROW
+      | ^~~~~~~
+/usr/include/string.h:260:1: note:   conversion of argument 1 would be ill-formed:
+/home/maxheap/blanat/submissions/lmongol/main.c:234:63: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
+  234 |                         nlptr = strrchr(pages[id] + PAGE_SIZE - 40, '\n') + 1;
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~^~~~
+      |                                                               |
+      |                                                               void*
+/home/maxheap/blanat/submissions/lmongol/main.c:246:40: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
+  246 |                 basket_compute(pages[id], id);
+      |                                ~~~~~~~~^
+      |                                        |
+      |                                        void*
+/home/maxheap/blanat/submissions/lmongol/main.c:203:27: note:   initializing argument 1 of ‘void basket_compute(char*, int)’
+  203 | void basket_compute(char *page, int id){
+      |                     ~~~~~~^~~~
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘void write_sorted(int, FILE*)’:
+/home/maxheap/blanat/submissions/lmongol/main.c:268:100: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+  268 |                                         fprintf(output, "%s %.2lf\n", kgroc[cities_baskets[lower][x]],
+      |                                                                             ~~~~~~~~~~~~~~~~~~~~~~~^
+/home/maxheap/blanat/submissions/lmongol/main.c: In function ‘int main(int, char**)’:
+/home/maxheap/blanat/submissions/lmongol/main.c:312:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  312 |                 filename = "input.txt";
+      |                            ^~~~~~~~~~~
+[2024-03-10T12:18:00Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpp9Pr87/sol" with exit code: exit status: 1
+[2024-03-10T12:18:00Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/lmongol/main.c", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "lmongol" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T12:18:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ERR-Elhim/main.cpp"
+[2024-03-10T12:18:01Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpsmoupf/sol" with exit code: exit status: 0
+[2024-03-10T12:18:01Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:18:01Z DEBUG blarun] The current started process has pid: 326816
+[2024-03-10T12:18:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:02Z DEBUG blarun] Correctness execution finished in: 149.969671ms
+[2024-03-10T12:18:02Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:18:02Z DEBUG blarun] Comparing output "/tmp/.tmpMdcg5E/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:18:02Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45535
+    Zucchini: 1.05
+    Pineapple: 1.06
+    Dill: 1.15
+    Eggplant: 1.22
+    Cantaloupe: 1.41
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T12:18:02Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:18:02Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:18:02Z INFO  blarun] Submission from user: ERR-Elhim has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:18:02Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Smartdev110/Main.java"
+[2024-03-10T12:18:02Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpHumT3b/Main.java" with exit code: exit status: 0
+[2024-03-10T12:18:02Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:18:02Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Smartdev110/Main.java" to "/tmp/.tmpzPar1j/Main.java"
+[2024-03-10T12:18:02Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:18:03Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpzPar1j/Main.java" with exit code: exit status: 0
+[2024-03-10T12:18:03Z DEBUG blarun] The current started process has pid: 326896
+[2024-03-10T12:18:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:03Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:03Z DEBUG blarun] Correctness execution finished in: 279.677111ms
+[2024-03-10T12:18:03Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:18:03Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:18:03Z DEBUG blarun] The current started process has pid: 326920
+[2024-03-10T12:18:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:03Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:03Z DEBUG blarun] Correctness execution finished in: 275.55063ms
+[2024-03-10T12:18:03Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:18:03Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:18:03Z DEBUG blarun] The current started process has pid: 326944
+[2024-03-10T12:18:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:04Z DEBUG blarun] Correctness execution finished in: 275.335558ms
+[2024-03-10T12:18:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:18:04Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:18:04Z DEBUG blarun] The current started process has pid: 326968
+[2024-03-10T12:18:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:04Z DEBUG blarun] Correctness execution finished in: 275.472374ms
+[2024-03-10T12:18:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:18:04Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:18:04Z DEBUG blarun] The current started process has pid: 326992
+[2024-03-10T12:18:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:04Z DEBUG blarun] Correctness execution finished in: 286.029974ms
+[2024-03-10T12:18:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:18:04Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:18:04Z DEBUG blarun] The current started process has pid: 327016
+[2024-03-10T12:18:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:05Z DEBUG blarun] Correctness execution finished in: 281.57671ms
+[2024-03-10T12:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:18:05Z DEBUG blarun] The current started process has pid: 327040
+[2024-03-10T12:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:05Z DEBUG blarun] Correctness execution finished in: 277.06597ms
+[2024-03-10T12:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:18:05Z DEBUG blarun] The current started process has pid: 327064
+[2024-03-10T12:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:05Z DEBUG blarun] Correctness execution finished in: 265.554627ms
+[2024-03-10T12:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:18:05Z DEBUG blarun] The current started process has pid: 327088
+[2024-03-10T12:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:05Z DEBUG blarun] Correctness execution finished in: 277.207869ms
+[2024-03-10T12:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:18:05Z DEBUG blarun] The current started process has pid: 327112
+[2024-03-10T12:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:18:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:18:06Z DEBUG blarun] Correctness execution finished in: 265.807597ms
+[2024-03-10T12:18:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:18:06Z DEBUG blarun] Comparing output "/tmp/.tmpzPar1j/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:18:06Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:18:06Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:18:07Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpHumT3b/input.txt"
+[2024-03-10T12:18:07Z DEBUG blarun] Starting execution run #0
+[2024-03-10T12:18:07Z DEBUG blarun] The current started process has pid: 327139
+[2024-03-10T12:18:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:28:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:28:06Z DEBUG blarun] Execution #0 finished in: 598.807384802s
+[2024-03-10T12:28:06Z DEBUG blarun] Computing verdict using "/tmp/.tmpHumT3b/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:28:06Z DEBUG blarun] Comparing output "/tmp/.tmpHumT3b/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:28:06Z DEBUG blarun] Starting execution run #1
+[2024-03-10T12:28:06Z DEBUG blarun] The current started process has pid: 327183
+[2024-03-10T12:28:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:06Z DEBUG blarun] Child process timed out
+[2024-03-10T12:38:06Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T12:38:06Z INFO  blarun] Submission from user: Smartdev110 has finished with verdict: Tle and with an AVG execution time of: 598.807384802s and MED of 598.807384802s
+[2024-03-10T12:38:06Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/sohaibMan/solution.rs"
+[2024-03-10T12:38:06Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/sohaibMan/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "sohaibMan" } with error: No such file or directory (os error 2)
+[2024-03-10T12:38:06Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mrurespect/Solution.py"
+[2024-03-10T12:38:06Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:38:06Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/mrurespect/Solution.py" to "/tmp/.tmp62CgE7/main.py"
+[2024-03-10T12:38:06Z DEBUG blarun] The current started process has pid: 330284
+[2024-03-10T12:38:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:06Z DEBUG blarun] Correctness execution finished in: 112.832641ms
+[2024-03-10T12:38:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:06Z DEBUG blarun] Comparing output "/tmp/.tmp62CgE7/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:06Z DEBUG blarun] The current started process has pid: 330285
+[2024-03-10T12:38:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:06Z DEBUG blarun] Correctness execution finished in: 86.699675ms
+[2024-03-10T12:38:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:38:06Z DEBUG blarun] Comparing output "/tmp/.tmp62CgE7/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:38:06Z DEBUG blarun] The current started process has pid: 330286
+[2024-03-10T12:38:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:06Z DEBUG blarun] Correctness execution finished in: 87.645567ms
+[2024-03-10T12:38:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:38:06Z DEBUG blarun] Comparing output "/tmp/.tmp62CgE7/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:38:06Z DEBUG blarun] The current started process has pid: 330287
+[2024-03-10T12:38:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:06Z DEBUG blarun] Correctness execution finished in: 87.067425ms
+[2024-03-10T12:38:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:38:06Z DEBUG blarun] Comparing output "/tmp/.tmp62CgE7/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:38:06Z INFO  blarun] Solution comparison failed, output for the solution is: Safi 44921.59
+    Plantain 1.04
+    Salsify 1.32
+    Potato 1.32
+    Artichoke 1.76
+    Bell_Pepper 1.77
+    
+     expected output is Safi 44921.59
+    Plantain 1.04
+    Potato 1.32
+    Salsify 1.32
+    Artichoke 1.76
+    Bell_Pepper 1.77
+    
+[2024-03-10T12:38:06Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:38:06Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:38:06Z INFO  blarun] Submission from user: mrurespect has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:38:06Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mrurespect/main.cpp"
+[2024-03-10T12:38:08Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpIDWXPd/sol" with exit code: exit status: 0
+[2024-03-10T12:38:08Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:38:08Z DEBUG blarun] The current started process has pid: 330317
+[2024-03-10T12:38:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:08Z DEBUG blarun] Correctness execution finished in: 99.10132ms
+[2024-03-10T12:38:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:08Z DEBUG blarun] Comparing output "/tmp/.tmpRRtKNI/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:08Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.980000
+    Zucchini 1.050000
+    Pineapple 1.060000
+    Dill 1.150000
+    Eggplant 1.220000
+    Cantaloupe 1.410000
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T12:38:08Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T12:38:08Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T12:38:08Z INFO  blarun] Submission from user: mrurespect has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:38:08Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mrurespect/Main.java"
+[2024-03-10T12:38:09Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpW7FNm7/Main.java" with exit code: exit status: 0
+[2024-03-10T12:38:09Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:38:09Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/mrurespect/Main.java" to "/tmp/.tmpW7WvR7/Main.java"
+[2024-03-10T12:38:09Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:38:10Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpW7WvR7/Main.java" with exit code: exit status: 0
+[2024-03-10T12:38:10Z DEBUG blarun] The current started process has pid: 330385
+[2024-03-10T12:38:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:10Z DEBUG blarun] Correctness execution finished in: 321.670445ms
+[2024-03-10T12:38:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:10Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:38:10Z DEBUG blarun] The current started process has pid: 330411
+[2024-03-10T12:38:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:10Z DEBUG blarun] Correctness execution finished in: 299.264833ms
+[2024-03-10T12:38:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:38:10Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:38:10Z DEBUG blarun] The current started process has pid: 330437
+[2024-03-10T12:38:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:11Z DEBUG blarun] Correctness execution finished in: 308.455708ms
+[2024-03-10T12:38:11Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:38:11Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:38:11Z DEBUG blarun] The current started process has pid: 330463
+[2024-03-10T12:38:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:11Z DEBUG blarun] Correctness execution finished in: 280.623884ms
+[2024-03-10T12:38:11Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:38:11Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:38:11Z DEBUG blarun] The current started process has pid: 330487
+[2024-03-10T12:38:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:11Z DEBUG blarun] Correctness execution finished in: 305.528689ms
+[2024-03-10T12:38:11Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:38:11Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:38:11Z DEBUG blarun] The current started process has pid: 330517
+[2024-03-10T12:38:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:12Z DEBUG blarun] Correctness execution finished in: 317.470319ms
+[2024-03-10T12:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:38:12Z DEBUG blarun] The current started process has pid: 330543
+[2024-03-10T12:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:12Z DEBUG blarun] Correctness execution finished in: 323.456258ms
+[2024-03-10T12:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:38:12Z DEBUG blarun] The current started process has pid: 330569
+[2024-03-10T12:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:12Z DEBUG blarun] Correctness execution finished in: 311.751931ms
+[2024-03-10T12:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:38:12Z DEBUG blarun] The current started process has pid: 330593
+[2024-03-10T12:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:12Z DEBUG blarun] Correctness execution finished in: 296.184478ms
+[2024-03-10T12:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:38:12Z DEBUG blarun] The current started process has pid: 330617
+[2024-03-10T12:38:13Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:38:13Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:38:13Z DEBUG blarun] Correctness execution finished in: 304.128782ms
+[2024-03-10T12:38:13Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:38:13Z DEBUG blarun] Comparing output "/tmp/.tmpW7WvR7/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:38:13Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:38:13Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:38:14Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpW7FNm7/input.txt"
+[2024-03-10T12:38:14Z DEBUG blarun] Starting execution run #0
+[2024-03-10T12:38:14Z DEBUG blarun] The current started process has pid: 330655
+[2024-03-10T12:38:14Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:14Z DEBUG blarun] Child process timed out
+[2024-03-10T12:48:14Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T12:48:14Z INFO  blarun] Submission from user: mrurespect has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T12:48:14Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/yousfiSaad/main.cpp"
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In member function ‘custom_map::t2 custom_map::CMap::get(const char*)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:78:32: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+   78 |       } else if (node.nexts[c[i]] == 0) {
+      |                             ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:80:23: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+   80 |         node.nexts[c[i]] = next_i;
+      |                    ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:82:32: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+   82 |         next_i = node.nexts[c[i]];
+      |                             ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In member function ‘custom_map::t2 custom_map::CMap::get(const char*, size_t)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:115:32: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+  115 |       } else if (node.nexts[c[i]] == 0) {
+      |                             ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:117:23: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+  117 |         node.nexts[c[i]] = next_i;
+      |                    ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:119:32: warning: array subscript has type ‘char’ [-Wchar-subscripts]
+  119 |         next_i = node.nexts[c[i]];
+      |                             ~~~^
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In constructor ‘FileReader_mem::FileReader_mem(bool, off_t, const off_t*)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:172:11: warning: unused variable ‘size’ [-Wunused-variable]
+  172 |     off_t size = pSize == NULL ? sb.st_size : *pSize;
+      |           ^~~~
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In function ‘void printResult2(Data&)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:287:30: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::array<long unsigned int, 6>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  287 |   for (int i = 0; i < 5 && i != vv.size(); ++i) {
+      |                            ~~^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In function ‘void merge2(Data&, Data&)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:310:14: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
+  310 |       if (jj == -1)
+      |           ~~~^~~~~
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In lambda function:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:381:17: warning: unused variable ‘last_chunk_size’ [-Wunused-variable]
+  381 |           off_t last_chunk_size = fr_m.file_size() - from;
+      |                 ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In function ‘int main()’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:394:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const unsigned int’ [-Wsign-compare]
+  394 |   for (int j = 0; j < number_of_threads; j++)
+      |                   ~~^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp: In function ‘void printResult2(Data&)’:
+/home/maxheap/blanat/submissions/yousfiSaad/main.cpp:289:18: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
+  289 |     fprintf(fp, "%s %ld.%02ld\n", data.products_index.name_from_idx(j),
+      |                  ^~
+[2024-03-10T12:48:15Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpvK2o5I/sol" with exit code: exit status: 0
+[2024-03-10T12:48:15Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:48:15Z DEBUG blarun] The current started process has pid: 331765
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 33.88127ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331798
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 30.437016ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331831
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 30.164304ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331864
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 29.095372ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331897
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 29.399385ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331930
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 47.304175ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331963
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 29.273145ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 331996
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 29.536089ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 332029
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 30.204157ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:48:16Z DEBUG blarun] The current started process has pid: 332062
+[2024-03-10T12:48:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:48:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:48:16Z DEBUG blarun] Correctness execution finished in: 30.693607ms
+[2024-03-10T12:48:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:48:16Z DEBUG blarun] Comparing output "/tmp/.tmp921q6z/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:48:16Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:48:16Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:48:17Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpvK2o5I/input.txt"
+[2024-03-10T12:48:17Z DEBUG blarun] Starting execution #0
+[2024-03-10T12:48:17Z DEBUG blarun] The current started process has pid: 332099
+[2024-03-10T12:48:17Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:49:36Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:49:36Z DEBUG blarun] Execution #0 finished in: 79.228802089s
+[2024-03-10T12:49:36Z DEBUG blarun] Computing verdict using "/tmp/.tmpvK2o5I/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:49:36Z DEBUG blarun] Comparing output "/tmp/.tmpvK2o5I/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:49:36Z DEBUG blarun] Starting execution #1
+[2024-03-10T12:49:36Z DEBUG blarun] The current started process has pid: 332134
+[2024-03-10T12:49:36Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:50:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:50:56Z DEBUG blarun] Execution #1 finished in: 79.184863531s
+[2024-03-10T12:50:56Z DEBUG blarun] Computing verdict using "/tmp/.tmpvK2o5I/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:50:56Z DEBUG blarun] Comparing output "/tmp/.tmpvK2o5I/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:50:56Z DEBUG blarun] Starting execution #2
+[2024-03-10T12:50:56Z DEBUG blarun] The current started process has pid: 332169
+[2024-03-10T12:50:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:52:15Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:52:15Z DEBUG blarun] Execution #2 finished in: 79.105014454s
+[2024-03-10T12:52:15Z DEBUG blarun] Computing verdict using "/tmp/.tmpvK2o5I/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:52:15Z DEBUG blarun] Comparing output "/tmp/.tmpvK2o5I/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:52:15Z DEBUG blarun] Starting execution #3
+[2024-03-10T12:52:15Z DEBUG blarun] The current started process has pid: 332203
+[2024-03-10T12:52:15Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:53:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:53:34Z DEBUG blarun] Execution #3 finished in: 79.062602863s
+[2024-03-10T12:53:34Z DEBUG blarun] Computing verdict using "/tmp/.tmpvK2o5I/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:53:34Z DEBUG blarun] Comparing output "/tmp/.tmpvK2o5I/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:53:34Z DEBUG blarun] Starting execution #4
+[2024-03-10T12:53:34Z DEBUG blarun] The current started process has pid: 332244
+[2024-03-10T12:53:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:53Z DEBUG blarun] Execution #4 finished in: 79.007137316s
+[2024-03-10T12:54:53Z DEBUG blarun] Computing verdict using "/tmp/.tmpvK2o5I/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:54:53Z DEBUG blarun] Comparing output "/tmp/.tmpvK2o5I/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:54:53Z INFO  blarun] Submission from user: yousfiSaad has finished with verdict: Ac and with an AVG execution time of: 79.117493616s and MED of 79.105014454s
+[2024-03-10T12:54:53Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/houcine7/Main.java"
+[2024-03-10T12:54:54Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp27lflw/Main.java" with exit code: exit status: 0
+[2024-03-10T12:54:54Z INFO  blarun] Starting correctness checks
+[2024-03-10T12:54:54Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/houcine7/Main.java" to "/tmp/.tmpCZkjDY/Main.java"
+[2024-03-10T12:54:54Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T12:54:54Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpCZkjDY/Main.java" with exit code: exit status: 0
+[2024-03-10T12:54:54Z DEBUG blarun] The current started process has pid: 332342
+[2024-03-10T12:54:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:55Z DEBUG blarun] Correctness execution finished in: 331.075161ms
+[2024-03-10T12:54:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:54:55Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T12:54:55Z DEBUG blarun] The current started process has pid: 332379
+[2024-03-10T12:54:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:55Z DEBUG blarun] Correctness execution finished in: 329.826152ms
+[2024-03-10T12:54:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:54:55Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T12:54:55Z DEBUG blarun] The current started process has pid: 332416
+[2024-03-10T12:54:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:55Z DEBUG blarun] Correctness execution finished in: 315.887453ms
+[2024-03-10T12:54:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:54:55Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T12:54:55Z DEBUG blarun] The current started process has pid: 332453
+[2024-03-10T12:54:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:56Z DEBUG blarun] Correctness execution finished in: 313.627727ms
+[2024-03-10T12:54:56Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:54:56Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T12:54:56Z DEBUG blarun] The current started process has pid: 332490
+[2024-03-10T12:54:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:56Z DEBUG blarun] Correctness execution finished in: 304.466122ms
+[2024-03-10T12:54:56Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:54:56Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T12:54:56Z DEBUG blarun] The current started process has pid: 332527
+[2024-03-10T12:54:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:56Z DEBUG blarun] Correctness execution finished in: 298.998466ms
+[2024-03-10T12:54:56Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:54:56Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T12:54:56Z DEBUG blarun] The current started process has pid: 332564
+[2024-03-10T12:54:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:57Z DEBUG blarun] Correctness execution finished in: 311.335746ms
+[2024-03-10T12:54:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:54:57Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T12:54:57Z DEBUG blarun] The current started process has pid: 332601
+[2024-03-10T12:54:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:57Z DEBUG blarun] Correctness execution finished in: 312.242797ms
+[2024-03-10T12:54:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:54:57Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T12:54:57Z DEBUG blarun] The current started process has pid: 332638
+[2024-03-10T12:54:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:57Z DEBUG blarun] Correctness execution finished in: 325.415489ms
+[2024-03-10T12:54:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:54:57Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T12:54:57Z DEBUG blarun] The current started process has pid: 332675
+[2024-03-10T12:54:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:54:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:54:58Z DEBUG blarun] Correctness execution finished in: 300.239049ms
+[2024-03-10T12:54:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:54:58Z DEBUG blarun] Comparing output "/tmp/.tmpCZkjDY/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T12:54:58Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T12:54:58Z INFO  blarun] Dropping the file cache
+[2024-03-10T12:54:59Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp27lflw/input.txt"
+[2024-03-10T12:54:59Z DEBUG blarun] Starting execution run #0
+[2024-03-10T12:54:59Z DEBUG blarun] The current started process has pid: 332715
+[2024-03-10T12:54:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T12:58:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T12:58:34Z DEBUG blarun] Execution #0 finished in: 214.632175365s
+[2024-03-10T12:58:34Z DEBUG blarun] Computing verdict using "/tmp/.tmp27lflw/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:58:34Z DEBUG blarun] Comparing output "/tmp/.tmp27lflw/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T12:58:34Z DEBUG blarun] Starting execution run #1
+[2024-03-10T12:58:34Z DEBUG blarun] The current started process has pid: 332780
+[2024-03-10T12:58:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:01:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:01:42Z DEBUG blarun] Execution #1 finished in: 187.685274429s
+[2024-03-10T13:01:42Z DEBUG blarun] Computing verdict using "/tmp/.tmp27lflw/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:01:42Z DEBUG blarun] Comparing output "/tmp/.tmp27lflw/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:01:42Z DEBUG blarun] Starting execution run #2
+[2024-03-10T13:01:42Z DEBUG blarun] The current started process has pid: 332852
+[2024-03-10T13:01:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:04:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:04:44Z DEBUG blarun] Execution #2 finished in: 182.891667423s
+[2024-03-10T13:04:44Z DEBUG blarun] Computing verdict using "/tmp/.tmp27lflw/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:04:44Z DEBUG blarun] Comparing output "/tmp/.tmp27lflw/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:04:44Z DEBUG blarun] Starting execution run #3
+[2024-03-10T13:04:44Z DEBUG blarun] The current started process has pid: 332924
+[2024-03-10T13:04:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:08:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:08:25Z DEBUG blarun] Execution #3 finished in: 220.521939374s
+[2024-03-10T13:08:25Z DEBUG blarun] Computing verdict using "/tmp/.tmp27lflw/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:08:25Z DEBUG blarun] Comparing output "/tmp/.tmp27lflw/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:08:25Z DEBUG blarun] Starting execution run #4
+[2024-03-10T13:08:25Z DEBUG blarun] The current started process has pid: 332991
+[2024-03-10T13:08:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:26Z DEBUG blarun] Execution #4 finished in: 180.69963094s
+[2024-03-10T13:11:26Z DEBUG blarun] Computing verdict using "/tmp/.tmp27lflw/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:11:26Z DEBUG blarun] Comparing output "/tmp/.tmp27lflw/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:11:26Z INFO  blarun] Submission from user: houcine7 has finished with verdict: Ac and with an AVG execution time of: 195.069705739s and MED of 187.685274429s
+[2024-03-10T13:11:26Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp"
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:26: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                          ^~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:32: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                       ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:46: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                              ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:53: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                     ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:68: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                    ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:76: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                    ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:92: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:100: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                    ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:108: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:116: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                                    ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:125: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                                             ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:134: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                                                      ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:129:143: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  129 | char *city_names[101] = {"Fes","Assa","Safi","Sale","Taza","Ahfir","Azrou","Midar","Nador","Oujda","Rabat","Smara","Agadir","Aourir","Arfoud","Asilah",
+      |                                                                                                                                               ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      | ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:10: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |          ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                   ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                            ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                     ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:46: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                              ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:55: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                       ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:64: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:73: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                         ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                  ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:91: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                           ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:100: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                    ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:109: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                             ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:118: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                                      ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:127: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                                               ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:136: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                                                        ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:130:145: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  130 | "Azilal","Dakhla","Drarga","Figuig","Ifrane","Jerada","Meknes","Midelt","Saidia","Sefrou","Settat","Temara","Tichka","Tichla","Tiflet","Tiznit","Zagora",
+      |                                                                                                                                                 ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      | ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:11: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |           ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:21: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                     ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:31: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                               ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                         ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:51: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                   ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                             ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:71: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                       ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                 ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:91: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                           ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:101: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                                     ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:111: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                                               ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:121: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                                                         ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:131: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                                                                   ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:131:141: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  131 | "Berkane","Bouarfa","Demnate","Guelmim","Guercif","Kenitra","Larache","Layoune","Tan-Tan","Tangier","Tarfaya","Tetouan","Tinghir","Zemamra","Akhfenir",
+      |                                                                                                                                             ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      | ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:12: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |            ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:23: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                       ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                  ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                             ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                        ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                   ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                              ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:89: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:100: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                                    ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:111: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                                               ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:122: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                                                          ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:134: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                                                                      ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:132:146: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  132 | "Bab_Taza","Boujdour","Goulmima","Imzouren","Inezgane","Khenifra","Laayoune","Ouazzane","Skhirate","Tafraout","Taourirt","Berrechid","Boulemane","Chichaoua",
+      |                                                                                                                                                  ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      | ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:13: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |             ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                         ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                 ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                            ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:72: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                        ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                    ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:96: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                                ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:109: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                                             ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:122: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                                                          ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:135: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                                                                       ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:133:148: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  133 | "El_Jadida","Essaouira","Khemisset","Khouribga","Laâyoune","Marrakech","Sidi_Ifni","Taroudant","Al_Hoceima","Bab_Berred","Ben_guerir","Bir_Lehlou","Bni_Hadifa",
+      |                                                                                                                                                    ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      | ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |              ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:27: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                           ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:40: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                        ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:53: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                     ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:66: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                  ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:79: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                               ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:92: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                                            ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:106: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                                                          ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:120: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                                                                        ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:134: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                                                                                      ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:134:148: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  134 | "Casablanca","Errachidia","Guerguerat","Mohammedia","Ouarzazate","Sidi_Kacem","Youssoufia","Ait_Melloul","Beni_Mellal","Chefchaouen","Oujda_Angad","Oulad_Teima",
+      |                                                                                                                                                    ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      | ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:15: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |               ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:29: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                             ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:43: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                           ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                         ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:72: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                        ^~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:90: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                                          ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:105: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                                                         ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:120: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                                                                        ^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:140: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                                                                                            ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:135:156: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  135 | "Sidi_Bouzid","Souk_Larbaa","had_soualem","Béni_Mellal","Bir_Anzerane","Fquih_Ben_Salah","Sidi_Bennour","Sidi_Slimane","Moulay_Bousselham","Guelta_Zemmur","Jorf_El_Melha",
+      |                                                                                                                                                            ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:136:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  136 | "Ksar_es_Seghir","Kalaat_MGouna","Ksar_El_Kebir",};
+      | ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:136:18: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  136 | "Ksar_es_Seghir","Kalaat_MGouna","Ksar_El_Kebir",};
+      |                  ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:136:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  136 | "Ksar_es_Seghir","Kalaat_MGouna","Ksar_El_Kebir",};
+      |                                  ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                            ^~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                  ^~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:40: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                        ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:47: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                               ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                      ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                             ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:68: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                    ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:75: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                           ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                  ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:89: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                         ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:96: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:103: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                       ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:110: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                              ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:117: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                                     ^~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:124: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:132: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                                                    ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:140: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                                                            ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:139:148: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  139 | char *product_names[94] = {"Fig","Yam","Beet","Date","Dill","Kale","Kiwi","Lime","Mint","Okra","Pear","Peas","Plum","Sage","Apple","Basil","Chard","Guava",
+      |                                                                                                                                                    ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      | ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:9: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |         ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:17: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                 ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                         ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                 ^~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                         ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:50: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                  ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                           ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:68: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                    ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:77: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                             ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:86: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                      ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:95: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                               ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:104: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                        ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:113: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                                 ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:122: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                                          ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:131: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                                                   ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:140: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                                                            ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:140:149: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  140 | "Lemon","Mango","Onion","Peach","Thyme","Banana","Carrot","Celery","Cherry","Endive","Garlic","Ginger","Grapes","Jicama","Kiwano","Orange","Papaya","Potato",
+      |                                                                                                                                                     ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      | ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:10: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |          ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:19: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                   ^~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:28: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                            ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                      ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:48: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:58: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                          ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:68: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                    ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                              ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:88: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                        ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:98: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                  ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:108: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                            ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:118: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                                      ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:128: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                                                ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:138: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                                                          ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:141:148: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  141 | "Radish","Tomato","Turnip","Apricot","Avocado","Cabbage","Coconut","Currant","Lettuce","Oregano","Parsley","Parsnip","Pumpkin","Rhubarb","Salsify","Spinach",
+      |                                                                                                                                                    ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      | ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:12: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |            ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:23: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                       ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                  ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:45: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                             ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                        ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                   ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                              ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:89: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:100: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                                    ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:111: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                                               ^~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:122: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                                                          ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:134: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                                                                      ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:142:146: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  142 | "Bok_Choy","Broccoli","Cilantro","Cucumber","Eggplant","Honeydew","Kohlrabi","Plantain","Rosemary","Rutabaga","Zucchini","Artichoke","Asparagus","Blueberry",
+      |                                                                                                                                                  ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      | ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:13: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |             ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:25: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                         ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                     ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:49: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                 ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                             ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:73: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                         ^~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:85: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                     ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:98: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                                  ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:111: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                                               ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:124: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                                                            ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:137: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                                                                         ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:143:150: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  143 | "Cranberry","Jackfruit","Nectarine","Persimmon","Pineapple","Raspberry","Starfruit","Blackberry","Cantaloupe","Clementine","Goji_Berry","Grapefruit","Strawberry",
+      |                                                                                                                                                      ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      | ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |              ^~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:27: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                           ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                         ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:55: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                       ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:69: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                     ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:83: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                                   ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:97: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                                                 ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:112: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                                                                ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:127: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                                                                               ^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:144:142: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  144 | "Watercress","Watermelon","Bell_Pepper","Cactus_Pear","Cauliflower","Green_Beans","Pomegranate","Acorn_Squash","Dragon_Fruit","Sweet_Potato","Butternut_Squash",
+      |                                                                                                                                              ^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:145:1: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  145 | "Brussels_Sprouts","Passion_Fruit","Collard_Greens","Squash_Blossom",};
+      | ^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:145:20: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  145 | "Brussels_Sprouts","Passion_Fruit","Collard_Greens","Squash_Blossom",};
+      |                    ^~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:145:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  145 | "Brussels_Sprouts","Passion_Fruit","Collard_Greens","Squash_Blossom",};
+      |                                    ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:145:53: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  145 | "Brussels_Sprouts","Passion_Fruit","Collard_Greens","Squash_Blossom",};
+      |                                                     ^~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp: In function ‘void* read_file(void*)’:
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:218:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  218 |     if (thread_id == num_threads - 1)
+      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:252:17: warning: unused variable ‘len_price’ [-Wunused-variable]
+  252 |             int len_price = end - price;
+      |                 ^~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp: In function ‘int main()’:
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:395:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
+  395 |     for(int i = 0; i < num_threads; i++)
+      |                    ~~^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:407:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
+  407 |     for(int i = 0; i < num_threads; i++)
+      |                    ~~^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:415:17: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
+  415 |     while(start <= num_threads)
+      |           ~~~~~~^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:421:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
+  421 |         while(second < num_threads)
+      |               ~~~~~~~^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:423:36: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
+  423 |             if (second + start / 2 > num_threads)
+      |                 ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/ILKAY-BRAHIM/main.cpp:443:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<int>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  443 |     for(int i = 0; i < vec.size(); i++)
+      |                    ~~^~~~~~~~~~~~
+[2024-03-10T13:11:27Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpnKx5jP/sol" with exit code: exit status: 0
+[2024-03-10T13:11:27Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333092
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 35.290678ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333156
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 16.746438ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333220
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 17.11555ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333284
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 17.578695ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333348
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 15.41174ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333412
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 15.772538ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333476
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 16.04618ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333540
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 16.268455ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333604
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 16.333977ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:11:27Z DEBUG blarun] The current started process has pid: 333668
+[2024-03-10T13:11:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:11:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:11:27Z DEBUG blarun] Correctness execution finished in: 15.898695ms
+[2024-03-10T13:11:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:11:27Z DEBUG blarun] Comparing output "/tmp/.tmp2emnkY/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:11:27Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:11:27Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:11:28Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpnKx5jP/input.txt"
+[2024-03-10T13:11:28Z DEBUG blarun] Starting execution #0
+[2024-03-10T13:11:28Z DEBUG blarun] The current started process has pid: 333734
+[2024-03-10T13:11:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:12:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:12:48Z DEBUG blarun] Execution #0 finished in: 79.214685272s
+[2024-03-10T13:12:48Z DEBUG blarun] Computing verdict using "/tmp/.tmpnKx5jP/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:12:48Z DEBUG blarun] Comparing output "/tmp/.tmpnKx5jP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:12:48Z DEBUG blarun] Starting execution #1
+[2024-03-10T13:12:48Z DEBUG blarun] The current started process has pid: 333801
+[2024-03-10T13:12:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:14:07Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:14:07Z DEBUG blarun] Execution #1 finished in: 79.165767424s
+[2024-03-10T13:14:07Z DEBUG blarun] Computing verdict using "/tmp/.tmpnKx5jP/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:14:07Z DEBUG blarun] Comparing output "/tmp/.tmpnKx5jP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:14:07Z DEBUG blarun] Starting execution #2
+[2024-03-10T13:14:07Z DEBUG blarun] The current started process has pid: 333870
+[2024-03-10T13:14:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:15:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:15:26Z DEBUG blarun] Execution #2 finished in: 79.075908883s
+[2024-03-10T13:15:26Z DEBUG blarun] Computing verdict using "/tmp/.tmpnKx5jP/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:15:26Z DEBUG blarun] Comparing output "/tmp/.tmpnKx5jP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:15:26Z DEBUG blarun] Starting execution #3
+[2024-03-10T13:15:26Z DEBUG blarun] The current started process has pid: 333936
+[2024-03-10T13:15:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:16:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:16:45Z DEBUG blarun] Execution #3 finished in: 78.987047298s
+[2024-03-10T13:16:45Z DEBUG blarun] Computing verdict using "/tmp/.tmpnKx5jP/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:16:45Z DEBUG blarun] Comparing output "/tmp/.tmpnKx5jP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:16:45Z DEBUG blarun] Starting execution #4
+[2024-03-10T13:16:45Z DEBUG blarun] The current started process has pid: 334000
+[2024-03-10T13:16:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:04Z DEBUG blarun] Execution #4 finished in: 79.006155664s
+[2024-03-10T13:18:04Z DEBUG blarun] Computing verdict using "/tmp/.tmpnKx5jP/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:18:04Z DEBUG blarun] Comparing output "/tmp/.tmpnKx5jP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:18:04Z INFO  blarun] Submission from user: ILKAY-BRAHIM has finished with verdict: Ac and with an AVG execution time of: 79.082610657s and MED of 79.075908883s
+[2024-03-10T13:18:04Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Anir-Ln/solution.cpp"
+/home/maxheap/blanat/submissions/Anir-Ln/solution.cpp: In function ‘void solve()’:
+/home/maxheap/blanat/submissions/Anir-Ln/solution.cpp:58:20: error: ‘setprecision’ was not declared in this scope
+   58 |   cout << fixed << setprecision(2);
+      |                    ^~~~~~~~~~~~
+[2024-03-10T13:18:05Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpplScJb/sol" with exit code: exit status: 1
+[2024-03-10T13:18:05Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/Anir-Ln/solution.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "Anir-Ln" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T13:18:05Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/youssefhamdane/solution.rs"
+[2024-03-10T13:18:05Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/youssefhamdane/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "youssefhamdane" } with error: No such file or directory (os error 2)
+[2024-03-10T13:18:05Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/sm3xy/solution.py"
+[2024-03-10T13:18:05Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:18:05Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/sm3xy/solution.py" to "/tmp/.tmpNuQ60s/main.py"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334071
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 105.903713ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334072
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 79.818674ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334073
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 81.104562ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334074
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 80.616234ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334075
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 79.857731ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334076
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 80.989513ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334077
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:05Z DEBUG blarun] Correctness execution finished in: 81.379009ms
+[2024-03-10T13:18:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:18:05Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:18:05Z DEBUG blarun] The current started process has pid: 334078
+[2024-03-10T13:18:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:06Z DEBUG blarun] Correctness execution finished in: 82.369176ms
+[2024-03-10T13:18:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:18:06Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:18:06Z DEBUG blarun] The current started process has pid: 334079
+[2024-03-10T13:18:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:06Z DEBUG blarun] Correctness execution finished in: 79.729784ms
+[2024-03-10T13:18:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:18:06Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:18:06Z DEBUG blarun] The current started process has pid: 334080
+[2024-03-10T13:18:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:18:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:18:06Z DEBUG blarun] Correctness execution finished in: 81.453262ms
+[2024-03-10T13:18:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:18:06Z DEBUG blarun] Comparing output "/tmp/.tmpNuQ60s/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:18:06Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:18:06Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:18:07Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpbpVMVH/input.txt"
+[2024-03-10T13:18:07Z DEBUG blarun] The current started process has pid: 334083
+[2024-03-10T13:18:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:08Z DEBUG blarun] Child process timed out
+[2024-03-10T13:28:08Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T13:28:08Z INFO  blarun] Submission from user: sm3xy has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T13:28:08Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Archesper/main.js"
+[2024-03-10T13:28:08Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:28:08Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Archesper/main.js" to "/tmp/.tmpwL6zTo/main.js"
+[2024-03-10T13:28:08Z DEBUG blarun] The current started process has pid: 334097
+[2024-03-10T13:28:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:08Z DEBUG blarun] Correctness execution finished in: 573.33189ms
+[2024-03-10T13:28:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:28:08Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:28:08Z DEBUG blarun] The current started process has pid: 334108
+[2024-03-10T13:28:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:08Z DEBUG blarun] Correctness execution finished in: 311.627508ms
+[2024-03-10T13:28:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:28:08Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:28:08Z DEBUG blarun] The current started process has pid: 334119
+[2024-03-10T13:28:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:09Z DEBUG blarun] Correctness execution finished in: 314.076092ms
+[2024-03-10T13:28:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:28:09Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:28:09Z DEBUG blarun] The current started process has pid: 334130
+[2024-03-10T13:28:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:09Z DEBUG blarun] Correctness execution finished in: 305.921876ms
+[2024-03-10T13:28:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:28:09Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:28:09Z DEBUG blarun] The current started process has pid: 334141
+[2024-03-10T13:28:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:09Z DEBUG blarun] Correctness execution finished in: 308.451936ms
+[2024-03-10T13:28:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:28:09Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:28:09Z DEBUG blarun] The current started process has pid: 334152
+[2024-03-10T13:28:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:10Z DEBUG blarun] Correctness execution finished in: 312.523309ms
+[2024-03-10T13:28:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:28:10Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:28:10Z DEBUG blarun] The current started process has pid: 334163
+[2024-03-10T13:28:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:10Z DEBUG blarun] Correctness execution finished in: 310.749849ms
+[2024-03-10T13:28:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:28:10Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:28:10Z DEBUG blarun] The current started process has pid: 334174
+[2024-03-10T13:28:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:10Z DEBUG blarun] Correctness execution finished in: 304.315634ms
+[2024-03-10T13:28:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:28:10Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:28:10Z DEBUG blarun] The current started process has pid: 334185
+[2024-03-10T13:28:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:11Z DEBUG blarun] Correctness execution finished in: 307.818254ms
+[2024-03-10T13:28:11Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:28:11Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:28:11Z DEBUG blarun] The current started process has pid: 334196
+[2024-03-10T13:28:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:28:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:28:11Z DEBUG blarun] Correctness execution finished in: 308.202116ms
+[2024-03-10T13:28:11Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:28:11Z DEBUG blarun] Comparing output "/tmp/.tmpwL6zTo/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:28:11Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:28:11Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp1jhMpB/input.txt"
+[2024-03-10T13:28:11Z DEBUG blarun] The current started process has pid: 334207
+[2024-03-10T13:28:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:11Z DEBUG blarun] Child process timed out
+[2024-03-10T13:38:11Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T13:38:11Z INFO  blarun] Submission from user: Archesper has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T13:38:11Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/aL0NEW0LF/main.c"
+/home/maxheap/blanat/submissions/aL0NEW0LF/main.c: In function ‘void* processBatch(void*)’:
+/home/maxheap/blanat/submissions/aL0NEW0LF/main.c:251:19: warning: unused variable ‘product’ [-Wunused-variable]
+  251 |             char* product = strtok(NULL, ",");
+      |                   ^~~~~~~
+[2024-03-10T13:38:12Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp5cJlQZ/sol" with exit code: exit status: 0
+[2024-03-10T13:38:12Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334904
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.74062ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334913
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.296216ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334922
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.043523ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334931
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.26906ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334940
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 42.10318ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334949
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.623332ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334958
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.028153ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334967
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 40.925477ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334976
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 41.833849ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:38:12Z DEBUG blarun] The current started process has pid: 334985
+[2024-03-10T13:38:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:12Z DEBUG blarun] Correctness execution finished in: 42.618044ms
+[2024-03-10T13:38:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:38:12Z DEBUG blarun] Comparing output "/tmp/.tmpt6xtMa/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:38:12Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:38:12Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:38:13Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp5cJlQZ/input.txt"
+[2024-03-10T13:38:13Z DEBUG blarun] Starting execution #0
+[2024-03-10T13:38:13Z DEBUG blarun] The current started process has pid: 334996
+[2024-03-10T13:38:13Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:28Z INFO  blarun] Finished execution of the solution with status: None
+[2024-03-10T13:38:28Z DEBUG blarun] Execution #0 finished in: 14.517166406s
+[2024-03-10T13:38:28Z DEBUG blarun] Computing verdict using "/tmp/.tmp5cJlQZ/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:38:28Z DEBUG blarun] Comparing output "/tmp/.tmp5cJlQZ/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:38:28Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/aL0NEW0LF/main.c", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "aL0NEW0LF" } with error: No such file or directory (os error 2)
+[2024-03-10T13:38:28Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/elmehdirida/Main.java"
+[2024-03-10T13:38:29Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp4kKwx1/Main.java" with exit code: exit status: 0
+[2024-03-10T13:38:29Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:38:29Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/elmehdirida/Main.java" to "/tmp/.tmpPNF8kk/Main.java"
+[2024-03-10T13:38:29Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T13:38:29Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpPNF8kk/Main.java" with exit code: exit status: 0
+[2024-03-10T13:38:29Z DEBUG blarun] The current started process has pid: 335070
+[2024-03-10T13:38:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:30Z DEBUG blarun] Correctness execution finished in: 247.784395ms
+[2024-03-10T13:38:30Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:30Z DEBUG blarun] Comparing output "/tmp/.tmpPNF8kk/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:30Z INFO  blarun] Solution comparison failed, output for the solution is: Arfoud 763.49
+    Kiwi 1.00
+    Oregano 1.12
+    Plantain 1.12
+    Raspberry 1.17
+    Carrot 1.26
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T13:38:30Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T13:38:30Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T13:38:30Z INFO  blarun] Submission from user: elmehdirida has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T13:38:30Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/aboullaite/Main.java"
+[2024-03-10T13:38:30Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpz89k9o/Main.java" with exit code: exit status: 0
+[2024-03-10T13:38:30Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:38:30Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/aboullaite/Main.java" to "/tmp/.tmp84f0ER/Main.java"
+[2024-03-10T13:38:30Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T13:38:31Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp84f0ER/Main.java" with exit code: exit status: 0
+[2024-03-10T13:38:31Z DEBUG blarun] The current started process has pid: 335167
+[2024-03-10T13:38:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:31Z DEBUG blarun] Correctness execution finished in: 452.704119ms
+[2024-03-10T13:38:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:31Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:38:31Z DEBUG blarun] The current started process has pid: 335216
+[2024-03-10T13:38:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:32Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:32Z DEBUG blarun] Correctness execution finished in: 418.867231ms
+[2024-03-10T13:38:32Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:38:32Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:38:32Z DEBUG blarun] The current started process has pid: 335265
+[2024-03-10T13:38:32Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:32Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:32Z DEBUG blarun] Correctness execution finished in: 421.086987ms
+[2024-03-10T13:38:32Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:38:32Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:38:32Z DEBUG blarun] The current started process has pid: 335314
+[2024-03-10T13:38:32Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:33Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:33Z DEBUG blarun] Correctness execution finished in: 412.118698ms
+[2024-03-10T13:38:33Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:38:33Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:38:33Z DEBUG blarun] The current started process has pid: 335363
+[2024-03-10T13:38:33Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:33Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:33Z DEBUG blarun] Correctness execution finished in: 368.28476ms
+[2024-03-10T13:38:33Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:38:33Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:38:33Z DEBUG blarun] The current started process has pid: 335412
+[2024-03-10T13:38:33Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:33Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:33Z DEBUG blarun] Correctness execution finished in: 418.127282ms
+[2024-03-10T13:38:33Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:38:33Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:38:33Z DEBUG blarun] The current started process has pid: 335461
+[2024-03-10T13:38:33Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:34Z DEBUG blarun] Correctness execution finished in: 453.30222ms
+[2024-03-10T13:38:34Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:38:34Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:38:34Z DEBUG blarun] The current started process has pid: 335510
+[2024-03-10T13:38:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:34Z DEBUG blarun] Correctness execution finished in: 418.639763ms
+[2024-03-10T13:38:34Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:38:34Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:38:34Z DEBUG blarun] The current started process has pid: 335559
+[2024-03-10T13:38:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:35Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:35Z DEBUG blarun] Correctness execution finished in: 428.844238ms
+[2024-03-10T13:38:35Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:38:35Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:38:35Z DEBUG blarun] The current started process has pid: 335608
+[2024-03-10T13:38:35Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:38:35Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:38:35Z DEBUG blarun] Correctness execution finished in: 427.502075ms
+[2024-03-10T13:38:35Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:38:35Z DEBUG blarun] Comparing output "/tmp/.tmp84f0ER/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:38:35Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:38:35Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:38:35Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpz89k9o/input.txt"
+[2024-03-10T13:38:35Z DEBUG blarun] Starting execution run #0
+[2024-03-10T13:38:35Z DEBUG blarun] The current started process has pid: 335659
+[2024-03-10T13:38:35Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:41:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:41:49Z DEBUG blarun] Execution #0 finished in: 193.406768073s
+[2024-03-10T13:41:49Z DEBUG blarun] Computing verdict using "/tmp/.tmpz89k9o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:41:49Z DEBUG blarun] Comparing output "/tmp/.tmpz89k9o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:41:49Z DEBUG blarun] Starting execution run #1
+[2024-03-10T13:41:49Z DEBUG blarun] The current started process has pid: 335759
+[2024-03-10T13:41:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:45:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:45:04Z DEBUG blarun] Execution #1 finished in: 194.829800518s
+[2024-03-10T13:45:04Z DEBUG blarun] Computing verdict using "/tmp/.tmpz89k9o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:45:04Z DEBUG blarun] Comparing output "/tmp/.tmpz89k9o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:45:04Z DEBUG blarun] Starting execution run #2
+[2024-03-10T13:45:04Z DEBUG blarun] The current started process has pid: 335829
+[2024-03-10T13:45:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:48:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:48:19Z DEBUG blarun] Execution #2 finished in: 195.42486977s
+[2024-03-10T13:48:19Z DEBUG blarun] Computing verdict using "/tmp/.tmpz89k9o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:48:19Z DEBUG blarun] Comparing output "/tmp/.tmpz89k9o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:48:19Z DEBUG blarun] Starting execution run #3
+[2024-03-10T13:48:19Z DEBUG blarun] The current started process has pid: 335907
+[2024-03-10T13:48:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:51:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:51:34Z DEBUG blarun] Execution #3 finished in: 194.724593872s
+[2024-03-10T13:51:34Z DEBUG blarun] Computing verdict using "/tmp/.tmpz89k9o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:51:34Z DEBUG blarun] Comparing output "/tmp/.tmpz89k9o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:51:34Z DEBUG blarun] Starting execution run #4
+[2024-03-10T13:51:34Z DEBUG blarun] The current started process has pid: 335981
+[2024-03-10T13:51:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:48Z DEBUG blarun] Execution #4 finished in: 194.662362329s
+[2024-03-10T13:54:48Z DEBUG blarun] Computing verdict using "/tmp/.tmpz89k9o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:54:48Z DEBUG blarun] Comparing output "/tmp/.tmpz89k9o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:54:48Z INFO  blarun] Submission from user: aboullaite has finished with verdict: Ac and with an AVG execution time of: 194.738918906s and MED of 194.724593872s
+[2024-03-10T13:54:48Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/AssmaaM/Solution.py"
+[2024-03-10T13:54:48Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:54:48Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/AssmaaM/Solution.py" to "/tmp/.tmpPK7UnG/main.py"
+[2024-03-10T13:54:48Z DEBUG blarun] The current started process has pid: 336049
+[2024-03-10T13:54:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 126.108104ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336050
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.980928ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336051
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.012417ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336052
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 100.382124ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336053
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.477724ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336054
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.602589ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336055
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.953589ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336056
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.540466ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336057
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:49Z DEBUG blarun] Correctness execution finished in: 98.624675ms
+[2024-03-10T13:54:49Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:54:49Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:54:49Z DEBUG blarun] The current started process has pid: 336058
+[2024-03-10T13:54:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:54:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:54:50Z DEBUG blarun] Correctness execution finished in: 101.541785ms
+[2024-03-10T13:54:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:54:50Z DEBUG blarun] Comparing output "/tmp/.tmpPK7UnG/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:54:50Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:54:50Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:54:51Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpkmHiVr/input.txt"
+[2024-03-10T13:54:51Z DEBUG blarun] The current started process has pid: 336061
+[2024-03-10T13:54:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:56Z INFO  blarun] Finished execution of the solution with status: None
+[2024-03-10T13:55:56Z DEBUG blarun] Execution #0 finished in: 65.498754853s
+[2024-03-10T13:55:56Z DEBUG blarun] Comparing output "/tmp/.tmpkmHiVr/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T13:55:56Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/AssmaaM/Solution.py", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "AssmaaM" } with error: No such file or directory (os error 2)
+[2024-03-10T13:55:56Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/mehdi-alouane/main.go"
+[2024-03-10T13:55:57Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpo2IK1w/sol" with exit code: exit status: 0
+[2024-03-10T13:55:57Z INFO  blarun] Starting correctness checks
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336235
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.410058ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336243
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.99157ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336252
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.314238ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336260
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.195619ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336268
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 52.689599ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336276
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 54.052687ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336285
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.422347ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336293
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 53.3983ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336302
+[2024-03-10T13:55:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:57Z DEBUG blarun] Correctness execution finished in: 54.35613ms
+[2024-03-10T13:55:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:55:57Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T13:55:57Z DEBUG blarun] The current started process has pid: 336310
+[2024-03-10T13:55:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T13:55:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T13:55:58Z DEBUG blarun] Correctness execution finished in: 53.387013ms
+[2024-03-10T13:55:58Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:55:58Z DEBUG blarun] Comparing output "/tmp/.tmpelYwzX/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T13:55:58Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T13:55:58Z INFO  blarun] Dropping the file cache
+[2024-03-10T13:55:58Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpo2IK1w/input.txt"
+[2024-03-10T13:55:58Z DEBUG blarun] Starting execution #0
+[2024-03-10T13:55:58Z DEBUG blarun] The current started process has pid: 336321
+[2024-03-10T13:55:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+panic: runtime error: invalid memory address or nil pointer dereference
+[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x80d36dd]
+
+goroutine 1 [running]:
+main.findCheapestCity(0x9504000)
+	/home/maxheap/blanat/submissions/mehdi-alouane/main.go:88 +0x9d
+main.main()
+	/home/maxheap/blanat/submissions/mehdi-alouane/main.go:28 +0x37
+[2024-03-10T14:04:25Z INFO  blarun] Finished execution of the solution with status: Some(2)
+[2024-03-10T14:04:25Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/mehdi-alouane/main.go", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "mehdi-alouane" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T14:04:25Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/.gitignore"
+[2024-03-10T14:04:25Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/.gitignore", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "submissions" } with error: failed to get file extension
+[2024-03-10T14:04:25Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/NotAsheraf/solution.rs"
+[2024-03-10T14:04:25Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/NotAsheraf/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "NotAsheraf" } with error: No such file or directory (os error 2)
+[2024-03-10T14:04:25Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/imOphen/main.py"
+[2024-03-10T14:04:25Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:04:25Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/imOphen/main.py" to "/tmp/.tmpKve7vW/main.py"
+[2024-03-10T14:04:25Z DEBUG blarun] The current started process has pid: 336348
+[2024-03-10T14:04:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:25Z DEBUG blarun] Correctness execution finished in: 203.945843ms
+[2024-03-10T14:04:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:04:25Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:04:25Z DEBUG blarun] The current started process has pid: 336368
+[2024-03-10T14:04:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:25Z DEBUG blarun] Correctness execution finished in: 134.390042ms
+[2024-03-10T14:04:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:04:25Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:04:25Z DEBUG blarun] The current started process has pid: 336388
+[2024-03-10T14:04:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 136.937111ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336410
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 135.675552ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336430
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 136.607101ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336450
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 138.466131ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336470
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 135.019524ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336490
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 138.007137ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336510
+[2024-03-10T14:04:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:26Z DEBUG blarun] Correctness execution finished in: 137.780664ms
+[2024-03-10T14:04:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:04:26Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:04:26Z DEBUG blarun] The current started process has pid: 336530
+[2024-03-10T14:04:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:04:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:04:27Z DEBUG blarun] Correctness execution finished in: 138.274471ms
+[2024-03-10T14:04:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:04:27Z DEBUG blarun] Comparing output "/tmp/.tmpKve7vW/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:04:27Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:04:27Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:04:28Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpJQN27M/input.txt"
+[2024-03-10T14:04:28Z DEBUG blarun] The current started process has pid: 336553
+[2024-03-10T14:04:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:06:07Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:06:07Z DEBUG blarun] Execution #0 finished in: 98.8818451s
+[2024-03-10T14:06:07Z DEBUG blarun] Comparing output "/tmp/.tmpJQN27M/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:06:07Z DEBUG blarun] The current started process has pid: 336574
+[2024-03-10T14:06:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:07:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:07:50Z DEBUG blarun] Execution #1 finished in: 103.432386618s
+[2024-03-10T14:07:50Z DEBUG blarun] Comparing output "/tmp/.tmpJQN27M/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:07:50Z DEBUG blarun] The current started process has pid: 336600
+[2024-03-10T14:07:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:09:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:09:34Z DEBUG blarun] Execution #2 finished in: 103.68384903s
+[2024-03-10T14:09:34Z DEBUG blarun] Comparing output "/tmp/.tmpJQN27M/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:09:34Z DEBUG blarun] The current started process has pid: 336651
+[2024-03-10T14:09:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:11:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:11:16Z DEBUG blarun] Execution #3 finished in: 102.611533773s
+[2024-03-10T14:11:16Z DEBUG blarun] Comparing output "/tmp/.tmpJQN27M/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:11:16Z DEBUG blarun] The current started process has pid: 336671
+[2024-03-10T14:11:17Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:12:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:12:59Z DEBUG blarun] Execution #4 finished in: 103.009599555s
+[2024-03-10T14:12:59Z DEBUG blarun] Comparing output "/tmp/.tmpJQN27M/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:12:59Z INFO  blarun] Submission from user: imOphen has finished with verdict: Ac and with an AVG execution time of: 103.017839982s and MED of 103.009599555s
+[2024-03-10T14:12:59Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp"
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: In function ‘u32 compute_product_index(char*, u32)’:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:136:14: warning: statement has no effect [-Wunused-value]
+  136 |   Assert(len >= 3);
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:25:21: note: in definition of macro ‘Assert’
+   25 | # define Assert(b) (b)
+      |                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: At global scope:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:175:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  175 |   string_lit("Acorn_Squash"),string_lit("Apple"),string_lit("Apricot"),string_lit("Artichoke"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:175:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  175 |   string_lit("Acorn_Squash"),string_lit("Apple"),string_lit("Apricot"),string_lit("Artichoke"),
+      |                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:175:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  175 |   string_lit("Acorn_Squash"),string_lit("Apple"),string_lit("Apricot"),string_lit("Artichoke"),
+      |                                                             ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:175:83: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  175 |   string_lit("Acorn_Squash"),string_lit("Apple"),string_lit("Apricot"),string_lit("Artichoke"),
+      |                                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:176:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  176 |   string_lit("Asparagus"),string_lit("Avocado"),string_lit("Banana"),string_lit("Basil"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:176:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  176 |   string_lit("Asparagus"),string_lit("Avocado"),string_lit("Banana"),string_lit("Basil"),
+      |                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:176:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  176 |   string_lit("Asparagus"),string_lit("Avocado"),string_lit("Banana"),string_lit("Basil"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:176:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  176 |   string_lit("Asparagus"),string_lit("Avocado"),string_lit("Banana"),string_lit("Basil"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:177:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  177 |   string_lit("Beet"),string_lit("Bell_Pepper"),string_lit("Blackberry"),string_lit("Blueberry"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:177:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  177 |   string_lit("Beet"),string_lit("Bell_Pepper"),string_lit("Blackberry"),string_lit("Blueberry"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:177:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  177 |   string_lit("Beet"),string_lit("Bell_Pepper"),string_lit("Blackberry"),string_lit("Blueberry"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:177:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  177 |   string_lit("Beet"),string_lit("Bell_Pepper"),string_lit("Blackberry"),string_lit("Blueberry"),
+      |                                                                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:178:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  178 |   string_lit("Bok_Choy"),string_lit("Broccoli"),string_lit("Brussels_Sprouts"),string_lit("Butternut_Squash"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:178:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  178 |   string_lit("Bok_Choy"),string_lit("Broccoli"),string_lit("Brussels_Sprouts"),string_lit("Butternut_Squash"),
+      |                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:178:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  178 |   string_lit("Bok_Choy"),string_lit("Broccoli"),string_lit("Brussels_Sprouts"),string_lit("Butternut_Squash"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:178:91: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  178 |   string_lit("Bok_Choy"),string_lit("Broccoli"),string_lit("Brussels_Sprouts"),string_lit("Butternut_Squash"),
+      |                                                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:179:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  179 |   string_lit("Cabbage"),string_lit("Cactus_Pear"),string_lit("Cantaloupe"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:179:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  179 |   string_lit("Cabbage"),string_lit("Cactus_Pear"),string_lit("Cantaloupe"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:179:62: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  179 |   string_lit("Cabbage"),string_lit("Cactus_Pear"),string_lit("Cantaloupe"),
+      |                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:180:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  180 |   string_lit("Carrot"),string_lit("Cauliflower"),string_lit("Celery"),string_lit("Chard"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:180:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  180 |   string_lit("Carrot"),string_lit("Cauliflower"),string_lit("Celery"),string_lit("Chard"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:180:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  180 |   string_lit("Carrot"),string_lit("Cauliflower"),string_lit("Celery"),string_lit("Chard"),
+      |                                                             ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:180:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  180 |   string_lit("Carrot"),string_lit("Cauliflower"),string_lit("Celery"),string_lit("Chard"),
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:181:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  181 |   string_lit("Cherry"),string_lit("Cilantro"),string_lit("Clementine"),string_lit("Coconut"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:181:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  181 |   string_lit("Cherry"),string_lit("Cilantro"),string_lit("Clementine"),string_lit("Coconut"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:181:58: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  181 |   string_lit("Cherry"),string_lit("Cilantro"),string_lit("Clementine"),string_lit("Coconut"),
+      |                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:181:83: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  181 |   string_lit("Cherry"),string_lit("Cilantro"),string_lit("Clementine"),string_lit("Coconut"),
+      |                                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:182:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  182 |   string_lit("Collard_Greens"),string_lit("Cranberry"),string_lit("Cucumber"),string_lit("Currant"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:182:43: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  182 |   string_lit("Collard_Greens"),string_lit("Cranberry"),string_lit("Cucumber"),string_lit("Currant"),
+      |                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:182:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  182 |   string_lit("Collard_Greens"),string_lit("Cranberry"),string_lit("Cucumber"),string_lit("Currant"),
+      |                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:182:90: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  182 |   string_lit("Collard_Greens"),string_lit("Cranberry"),string_lit("Cucumber"),string_lit("Currant"),
+      |                                                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:183:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  183 |   string_lit("Date"),string_lit("Dill"),string_lit("Dragon_Fruit"),string_lit("Eggplant"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:183:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  183 |   string_lit("Date"),string_lit("Dill"),string_lit("Dragon_Fruit"),string_lit("Eggplant"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:183:52: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  183 |   string_lit("Date"),string_lit("Dill"),string_lit("Dragon_Fruit"),string_lit("Eggplant"),
+      |                                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:183:79: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  183 |   string_lit("Date"),string_lit("Dill"),string_lit("Dragon_Fruit"),string_lit("Eggplant"),
+      |                                                                               ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:184:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  184 |   string_lit("Endive"),string_lit("Fig"),string_lit("Garlic"),string_lit("Ginger"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:184:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  184 |   string_lit("Endive"),string_lit("Fig"),string_lit("Garlic"),string_lit("Ginger"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:184:53: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  184 |   string_lit("Endive"),string_lit("Fig"),string_lit("Garlic"),string_lit("Ginger"),
+      |                                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:184:74: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  184 |   string_lit("Endive"),string_lit("Fig"),string_lit("Garlic"),string_lit("Ginger"),
+      |                                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:185:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  185 |   string_lit("Goji_Berry"),string_lit("Grapefruit"),string_lit("Grapes"),string_lit("Green_Beans"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:185:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  185 |   string_lit("Goji_Berry"),string_lit("Grapefruit"),string_lit("Grapes"),string_lit("Green_Beans"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:185:64: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  185 |   string_lit("Goji_Berry"),string_lit("Grapefruit"),string_lit("Grapes"),string_lit("Green_Beans"),
+      |                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:185:85: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  185 |   string_lit("Goji_Berry"),string_lit("Grapefruit"),string_lit("Grapes"),string_lit("Green_Beans"),
+      |                                                                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:186:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  186 |   string_lit("Guava"),string_lit("Honeydew"),string_lit("Jackfruit"),string_lit("Jicama"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:186:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  186 |   string_lit("Guava"),string_lit("Honeydew"),string_lit("Jackfruit"),string_lit("Jicama"),
+      |                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:186:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  186 |   string_lit("Guava"),string_lit("Honeydew"),string_lit("Jackfruit"),string_lit("Jicama"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:186:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  186 |   string_lit("Guava"),string_lit("Honeydew"),string_lit("Jackfruit"),string_lit("Jicama"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:187:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  187 |   string_lit("Kale"),string_lit("Kiwano"),string_lit("Kiwi"),string_lit("Kohlrabi"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:187:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  187 |   string_lit("Kale"),string_lit("Kiwano"),string_lit("Kiwi"),string_lit("Kohlrabi"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:187:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  187 |   string_lit("Kale"),string_lit("Kiwano"),string_lit("Kiwi"),string_lit("Kohlrabi"),
+      |                                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:187:73: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  187 |   string_lit("Kale"),string_lit("Kiwano"),string_lit("Kiwi"),string_lit("Kohlrabi"),
+      |                                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:188:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  188 |   string_lit("Lemon"),string_lit("Lettuce"),string_lit("Lime"),string_lit("Mango"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:188:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  188 |   string_lit("Lemon"),string_lit("Lettuce"),string_lit("Lime"),string_lit("Mango"),
+      |                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:188:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  188 |   string_lit("Lemon"),string_lit("Lettuce"),string_lit("Lime"),string_lit("Mango"),
+      |                                                        ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:188:75: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  188 |   string_lit("Lemon"),string_lit("Lettuce"),string_lit("Lime"),string_lit("Mango"),
+      |                                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:189:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  189 |   string_lit("Mint"),string_lit("Nectarine"),string_lit("Okra"),string_lit("Onion"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:189:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  189 |   string_lit("Mint"),string_lit("Nectarine"),string_lit("Okra"),string_lit("Onion"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:189:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  189 |   string_lit("Mint"),string_lit("Nectarine"),string_lit("Okra"),string_lit("Onion"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:189:76: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  189 |   string_lit("Mint"),string_lit("Nectarine"),string_lit("Okra"),string_lit("Onion"),
+      |                                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:190:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  190 |   string_lit("Orange"),string_lit("Oregano"),string_lit("Papaya"),string_lit("Parsley"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:190:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  190 |   string_lit("Orange"),string_lit("Oregano"),string_lit("Papaya"),string_lit("Parsley"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:190:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  190 |   string_lit("Orange"),string_lit("Oregano"),string_lit("Papaya"),string_lit("Parsley"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:190:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  190 |   string_lit("Orange"),string_lit("Oregano"),string_lit("Papaya"),string_lit("Parsley"),
+      |                                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:191:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  191 |   string_lit("Parsnip"),string_lit("Passion_Fruit"),string_lit("Peach"),string_lit("Pear"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:191:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  191 |   string_lit("Parsnip"),string_lit("Passion_Fruit"),string_lit("Peach"),string_lit("Pear"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:191:64: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  191 |   string_lit("Parsnip"),string_lit("Passion_Fruit"),string_lit("Peach"),string_lit("Pear"),
+      |                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:191:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  191 |   string_lit("Parsnip"),string_lit("Passion_Fruit"),string_lit("Peach"),string_lit("Pear"),
+      |                                                                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:192:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  192 |   string_lit("Peas"),string_lit("Persimmon"),string_lit("Pineapple"),string_lit("Plantain"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:192:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  192 |   string_lit("Peas"),string_lit("Persimmon"),string_lit("Pineapple"),string_lit("Plantain"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:192:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  192 |   string_lit("Peas"),string_lit("Persimmon"),string_lit("Pineapple"),string_lit("Plantain"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:192:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  192 |   string_lit("Peas"),string_lit("Persimmon"),string_lit("Pineapple"),string_lit("Plantain"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:193:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  193 |   string_lit("Plum"),string_lit("Pomegranate"),string_lit("Potato"),string_lit("Pumpkin"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:193:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  193 |   string_lit("Plum"),string_lit("Pomegranate"),string_lit("Potato"),string_lit("Pumpkin"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:193:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  193 |   string_lit("Plum"),string_lit("Pomegranate"),string_lit("Potato"),string_lit("Pumpkin"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:193:80: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  193 |   string_lit("Plum"),string_lit("Pomegranate"),string_lit("Potato"),string_lit("Pumpkin"),
+      |                                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:194:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  194 |   string_lit("Radish"),string_lit("Raspberry"),string_lit("Rhubarb"),string_lit("Rosemary"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:194:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  194 |   string_lit("Radish"),string_lit("Raspberry"),string_lit("Rhubarb"),string_lit("Rosemary"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:194:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  194 |   string_lit("Radish"),string_lit("Raspberry"),string_lit("Rhubarb"),string_lit("Rosemary"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:194:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  194 |   string_lit("Radish"),string_lit("Raspberry"),string_lit("Rhubarb"),string_lit("Rosemary"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:195:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  195 |   string_lit("Rutabaga"),string_lit("Sage"),string_lit("Salsify"),string_lit("Spinach"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:195:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  195 |   string_lit("Rutabaga"),string_lit("Sage"),string_lit("Salsify"),string_lit("Spinach"),
+      |                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:195:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  195 |   string_lit("Rutabaga"),string_lit("Sage"),string_lit("Salsify"),string_lit("Spinach"),
+      |                                                        ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:195:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  195 |   string_lit("Rutabaga"),string_lit("Sage"),string_lit("Salsify"),string_lit("Spinach"),
+      |                                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:196:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  196 |   string_lit("Squash_Blossom"),string_lit("Starfruit"),string_lit("Strawberry"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:196:43: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  196 |   string_lit("Squash_Blossom"),string_lit("Starfruit"),string_lit("Strawberry"),
+      |                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:196:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  196 |   string_lit("Squash_Blossom"),string_lit("Starfruit"),string_lit("Strawberry"),
+      |                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:197:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  197 |   string_lit("Sweet_Potato"),string_lit("Thyme"),string_lit("Tomato"),string_lit("Turnip"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:197:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  197 |   string_lit("Sweet_Potato"),string_lit("Thyme"),string_lit("Tomato"),string_lit("Turnip"),
+      |                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:197:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  197 |   string_lit("Sweet_Potato"),string_lit("Thyme"),string_lit("Tomato"),string_lit("Turnip"),
+      |                                                             ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:197:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  197 |   string_lit("Sweet_Potato"),string_lit("Thyme"),string_lit("Tomato"),string_lit("Turnip"),
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:198:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  198 |   string_lit("Watercress"),string_lit("Watermelon"),string_lit("Yam"),string_lit("Zucchini")
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:198:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  198 |   string_lit("Watercress"),string_lit("Watermelon"),string_lit("Yam"),string_lit("Zucchini")
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:198:64: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  198 |   string_lit("Watercress"),string_lit("Watermelon"),string_lit("Yam"),string_lit("Zucchini")
+      |                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:198:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  198 |   string_lit("Watercress"),string_lit("Watermelon"),string_lit("Yam"),string_lit("Zucchini")
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:203:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  203 |   string_lit("Agadir"),string_lit("Ahfir"),string_lit("Ait_Melloul"),string_lit("Akhfenir"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:203:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  203 |   string_lit("Agadir"),string_lit("Ahfir"),string_lit("Ait_Melloul"),string_lit("Akhfenir"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:203:55: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  203 |   string_lit("Agadir"),string_lit("Ahfir"),string_lit("Ait_Melloul"),string_lit("Akhfenir"),
+      |                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:203:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  203 |   string_lit("Agadir"),string_lit("Ahfir"),string_lit("Ait_Melloul"),string_lit("Akhfenir"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:204:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  204 |   string_lit("Al_Hoceima"),string_lit("Aourir"),string_lit("Arfoud"),string_lit("Asilah"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:204:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  204 |   string_lit("Al_Hoceima"),string_lit("Aourir"),string_lit("Arfoud"),string_lit("Asilah"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:204:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  204 |   string_lit("Al_Hoceima"),string_lit("Aourir"),string_lit("Arfoud"),string_lit("Asilah"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:204:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  204 |   string_lit("Al_Hoceima"),string_lit("Aourir"),string_lit("Arfoud"),string_lit("Asilah"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:205:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  205 |   string_lit("Assa"),string_lit("Azilal"),string_lit("Azrou"),string_lit("Béni_Mellal"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:205:33: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  205 |   string_lit("Assa"),string_lit("Azilal"),string_lit("Azrou"),string_lit("Béni_Mellal"),
+      |                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:205:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  205 |   string_lit("Assa"),string_lit("Azilal"),string_lit("Azrou"),string_lit("Béni_Mellal"),
+      |                                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:205:74: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  205 |   string_lit("Assa"),string_lit("Azilal"),string_lit("Azrou"),string_lit("Béni_Mellal"),
+      |                                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:206:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  206 |   string_lit("Bab_Berred"),string_lit("Bab_Taza"),string_lit("Ben_guerir"),string_lit("Beni_Mellal"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:206:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  206 |   string_lit("Bab_Berred"),string_lit("Bab_Taza"),string_lit("Ben_guerir"),string_lit("Beni_Mellal"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:206:62: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  206 |   string_lit("Bab_Berred"),string_lit("Bab_Taza"),string_lit("Ben_guerir"),string_lit("Beni_Mellal"),
+      |                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:206:87: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  206 |   string_lit("Bab_Berred"),string_lit("Bab_Taza"),string_lit("Ben_guerir"),string_lit("Beni_Mellal"),
+      |                                                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:207:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  207 |   string_lit("Berkane"),string_lit("Berrechid"),string_lit("Bir_Anzerane"),string_lit("Bir_Lehlou"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:207:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  207 |   string_lit("Berkane"),string_lit("Berrechid"),string_lit("Bir_Anzerane"),string_lit("Bir_Lehlou"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:207:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  207 |   string_lit("Berkane"),string_lit("Berrechid"),string_lit("Bir_Anzerane"),string_lit("Bir_Lehlou"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:207:87: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  207 |   string_lit("Berkane"),string_lit("Berrechid"),string_lit("Bir_Anzerane"),string_lit("Bir_Lehlou"),
+      |                                                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:208:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  208 |   string_lit("Bni_Hadifa"),string_lit("Bouarfa"),string_lit("Boujdour"),string_lit("Boulemane"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:208:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  208 |   string_lit("Bni_Hadifa"),string_lit("Bouarfa"),string_lit("Boujdour"),string_lit("Boulemane"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:208:61: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  208 |   string_lit("Bni_Hadifa"),string_lit("Bouarfa"),string_lit("Boujdour"),string_lit("Boulemane"),
+      |                                                             ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:208:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  208 |   string_lit("Bni_Hadifa"),string_lit("Bouarfa"),string_lit("Boujdour"),string_lit("Boulemane"),
+      |                                                                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:209:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  209 |   string_lit("Casablanca"),string_lit("Chefchaouen"),string_lit("Chichaoua"),string_lit("Dakhla"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:209:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  209 |   string_lit("Casablanca"),string_lit("Chefchaouen"),string_lit("Chichaoua"),string_lit("Dakhla"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:209:65: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  209 |   string_lit("Casablanca"),string_lit("Chefchaouen"),string_lit("Chichaoua"),string_lit("Dakhla"),
+      |                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:209:89: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  209 |   string_lit("Casablanca"),string_lit("Chefchaouen"),string_lit("Chichaoua"),string_lit("Dakhla"),
+      |                                                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:210:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  210 |   string_lit("Demnate"),string_lit("Drarga"),string_lit("El_Jadida"),string_lit("Errachidia"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:210:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  210 |   string_lit("Demnate"),string_lit("Drarga"),string_lit("El_Jadida"),string_lit("Errachidia"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:210:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  210 |   string_lit("Demnate"),string_lit("Drarga"),string_lit("El_Jadida"),string_lit("Errachidia"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:210:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  210 |   string_lit("Demnate"),string_lit("Drarga"),string_lit("El_Jadida"),string_lit("Errachidia"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:211:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  211 |   string_lit("Essaouira"),string_lit("Fes"),string_lit("Figuig"),string_lit("Fquih_Ben_Salah"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:211:38: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  211 |   string_lit("Essaouira"),string_lit("Fes"),string_lit("Figuig"),string_lit("Fquih_Ben_Salah"),
+      |                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:211:56: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  211 |   string_lit("Essaouira"),string_lit("Fes"),string_lit("Figuig"),string_lit("Fquih_Ben_Salah"),
+      |                                                        ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:211:77: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  211 |   string_lit("Essaouira"),string_lit("Fes"),string_lit("Figuig"),string_lit("Fquih_Ben_Salah"),
+      |                                                                             ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:212:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  212 |   string_lit("Goulmima"),string_lit("Guelmim"),string_lit("Guelta_Zemmur"),string_lit("Guercif"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:212:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  212 |   string_lit("Goulmima"),string_lit("Guelmim"),string_lit("Guelta_Zemmur"),string_lit("Guercif"),
+      |                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:212:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  212 |   string_lit("Goulmima"),string_lit("Guelmim"),string_lit("Guelta_Zemmur"),string_lit("Guercif"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:212:87: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  212 |   string_lit("Goulmima"),string_lit("Guelmim"),string_lit("Guelta_Zemmur"),string_lit("Guercif"),
+      |                                                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:213:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  213 |   string_lit("Guerguerat"),string_lit("had_soualem"),string_lit("Ifrane"),string_lit("Imzouren"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:213:39: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  213 |   string_lit("Guerguerat"),string_lit("had_soualem"),string_lit("Ifrane"),string_lit("Imzouren"),
+      |                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:213:65: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  213 |   string_lit("Guerguerat"),string_lit("had_soualem"),string_lit("Ifrane"),string_lit("Imzouren"),
+      |                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:213:86: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  213 |   string_lit("Guerguerat"),string_lit("had_soualem"),string_lit("Ifrane"),string_lit("Imzouren"),
+      |                                                                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:214:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  214 |   string_lit("Inezgane"),string_lit("Jerada"),string_lit("Jorf_El_Melha"),string_lit("Kalaat_MGouna"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:214:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  214 |   string_lit("Inezgane"),string_lit("Jerada"),string_lit("Jorf_El_Melha"),string_lit("Kalaat_MGouna"),
+      |                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:214:58: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  214 |   string_lit("Inezgane"),string_lit("Jerada"),string_lit("Jorf_El_Melha"),string_lit("Kalaat_MGouna"),
+      |                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:214:86: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  214 |   string_lit("Inezgane"),string_lit("Jerada"),string_lit("Jorf_El_Melha"),string_lit("Kalaat_MGouna"),
+      |                                                                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:215:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  215 |   string_lit("Kenitra"),string_lit("Khemisset"),string_lit("Khenifra"),string_lit("Khouribga"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:215:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  215 |   string_lit("Kenitra"),string_lit("Khemisset"),string_lit("Khenifra"),string_lit("Khouribga"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:215:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  215 |   string_lit("Kenitra"),string_lit("Khemisset"),string_lit("Khenifra"),string_lit("Khouribga"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:215:83: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  215 |   string_lit("Kenitra"),string_lit("Khemisset"),string_lit("Khenifra"),string_lit("Khouribga"),
+      |                                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:216:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  216 |   string_lit("Ksar_El_Kebir"),string_lit("Ksar_es_Seghir"),string_lit("Laâyoune"),string_lit("Laayoune"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:216:42: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  216 |   string_lit("Ksar_El_Kebir"),string_lit("Ksar_es_Seghir"),string_lit("Laâyoune"),string_lit("Laayoune"),
+      |                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:216:71: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  216 |   string_lit("Ksar_El_Kebir"),string_lit("Ksar_es_Seghir"),string_lit("Laâyoune"),string_lit("Laayoune"),
+      |                                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:216:94: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  216 |   string_lit("Ksar_El_Kebir"),string_lit("Ksar_es_Seghir"),string_lit("Laâyoune"),string_lit("Laayoune"),
+      |                                                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:217:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  217 |   string_lit("Larache"),string_lit("Layoune"),string_lit("Marrakech"),string_lit("Meknes"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:217:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  217 |   string_lit("Larache"),string_lit("Layoune"),string_lit("Marrakech"),string_lit("Meknes"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:217:58: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  217 |   string_lit("Larache"),string_lit("Layoune"),string_lit("Marrakech"),string_lit("Meknes"),
+      |                                                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:217:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  217 |   string_lit("Larache"),string_lit("Layoune"),string_lit("Marrakech"),string_lit("Meknes"),
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:218:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  218 |   string_lit("Midar"),string_lit("Midelt"),string_lit("Mohammedia"),string_lit("Moulay_Bousselham"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:218:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  218 |   string_lit("Midar"),string_lit("Midelt"),string_lit("Mohammedia"),string_lit("Moulay_Bousselham"),
+      |                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:218:55: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  218 |   string_lit("Midar"),string_lit("Midelt"),string_lit("Mohammedia"),string_lit("Moulay_Bousselham"),
+      |                                                       ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:218:80: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  218 |   string_lit("Midar"),string_lit("Midelt"),string_lit("Mohammedia"),string_lit("Moulay_Bousselham"),
+      |                                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:219:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  219 |   string_lit("Nador"),string_lit("Ouarzazate"),string_lit("Ouazzane"),string_lit("Oujda_Angad"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:219:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  219 |   string_lit("Nador"),string_lit("Ouarzazate"),string_lit("Ouazzane"),string_lit("Oujda_Angad"),
+      |                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:219:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  219 |   string_lit("Nador"),string_lit("Ouarzazate"),string_lit("Ouazzane"),string_lit("Oujda_Angad"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:219:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  219 |   string_lit("Nador"),string_lit("Ouarzazate"),string_lit("Ouazzane"),string_lit("Oujda_Angad"),
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:220:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  220 |   string_lit("Oujda"),string_lit("Oulad_Teima"),string_lit("Rabat"),string_lit("Safi"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:220:34: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  220 |   string_lit("Oujda"),string_lit("Oulad_Teima"),string_lit("Rabat"),string_lit("Safi"),
+      |                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:220:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  220 |   string_lit("Oujda"),string_lit("Oulad_Teima"),string_lit("Rabat"),string_lit("Safi"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:220:80: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  220 |   string_lit("Oujda"),string_lit("Oulad_Teima"),string_lit("Rabat"),string_lit("Safi"),
+      |                                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:221:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  221 |   string_lit("Saidia"),string_lit("Sale"),string_lit("Sefrou"),string_lit("Settat"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:221:35: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  221 |   string_lit("Saidia"),string_lit("Sale"),string_lit("Sefrou"),string_lit("Settat"),
+      |                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:221:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  221 |   string_lit("Saidia"),string_lit("Sale"),string_lit("Sefrou"),string_lit("Settat"),
+      |                                                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:221:75: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  221 |   string_lit("Saidia"),string_lit("Sale"),string_lit("Sefrou"),string_lit("Settat"),
+      |                                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:222:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  222 |   string_lit("Sidi_Bennour"),string_lit("Sidi_Bouzid"),string_lit("Sidi_Ifni"),string_lit("Sidi_Kacem"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:222:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  222 |   string_lit("Sidi_Bennour"),string_lit("Sidi_Bouzid"),string_lit("Sidi_Ifni"),string_lit("Sidi_Kacem"),
+      |                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:222:67: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  222 |   string_lit("Sidi_Bennour"),string_lit("Sidi_Bouzid"),string_lit("Sidi_Ifni"),string_lit("Sidi_Kacem"),
+      |                                                                   ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:222:91: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  222 |   string_lit("Sidi_Bennour"),string_lit("Sidi_Bouzid"),string_lit("Sidi_Ifni"),string_lit("Sidi_Kacem"),
+      |                                                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:223:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  223 |   string_lit("Sidi_Slimane"),string_lit("Skhirate"),string_lit("Smara"),string_lit("Souk_Larbaa"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:223:41: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  223 |   string_lit("Sidi_Slimane"),string_lit("Skhirate"),string_lit("Smara"),string_lit("Souk_Larbaa"),
+      |                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:223:64: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  223 |   string_lit("Sidi_Slimane"),string_lit("Skhirate"),string_lit("Smara"),string_lit("Souk_Larbaa"),
+      |                                                                ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:223:84: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  223 |   string_lit("Sidi_Slimane"),string_lit("Skhirate"),string_lit("Smara"),string_lit("Souk_Larbaa"),
+      |                                                                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:224:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  224 |   string_lit("Tafraout"),string_lit("Tan-Tan"),string_lit("Tangier"),string_lit("Taourirt"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:224:37: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  224 |   string_lit("Tafraout"),string_lit("Tan-Tan"),string_lit("Tangier"),string_lit("Taourirt"),
+      |                                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:224:59: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  224 |   string_lit("Tafraout"),string_lit("Tan-Tan"),string_lit("Tangier"),string_lit("Taourirt"),
+      |                                                           ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:224:81: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  224 |   string_lit("Tafraout"),string_lit("Tan-Tan"),string_lit("Tangier"),string_lit("Taourirt"),
+      |                                                                                 ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:225:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  225 |   string_lit("Tarfaya"),string_lit("Taroudant"),string_lit("Taza"),string_lit("Temara"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:225:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  225 |   string_lit("Tarfaya"),string_lit("Taroudant"),string_lit("Taza"),string_lit("Temara"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:225:60: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  225 |   string_lit("Tarfaya"),string_lit("Taroudant"),string_lit("Taza"),string_lit("Temara"),
+      |                                                            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:225:79: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  225 |   string_lit("Tarfaya"),string_lit("Taroudant"),string_lit("Taza"),string_lit("Temara"),
+      |                                                                               ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:226:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  226 |   string_lit("Tetouan"),string_lit("Tichka"),string_lit("Tichla"),string_lit("Tiflet"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:226:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  226 |   string_lit("Tetouan"),string_lit("Tichka"),string_lit("Tichla"),string_lit("Tiflet"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:226:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  226 |   string_lit("Tetouan"),string_lit("Tichka"),string_lit("Tichla"),string_lit("Tiflet"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:226:78: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  226 |   string_lit("Tetouan"),string_lit("Tichka"),string_lit("Tichla"),string_lit("Tiflet"),
+      |                                                                              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:227:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  227 |   string_lit("Tinghir"),string_lit("Tiznit"),string_lit("Youssoufia"),string_lit("Zagora"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:227:36: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  227 |   string_lit("Tinghir"),string_lit("Tiznit"),string_lit("Youssoufia"),string_lit("Zagora"),
+      |                                    ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:227:57: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  227 |   string_lit("Tinghir"),string_lit("Tiznit"),string_lit("Youssoufia"),string_lit("Zagora"),
+      |                                                         ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:227:82: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  227 |   string_lit("Tinghir"),string_lit("Tiznit"),string_lit("Youssoufia"),string_lit("Zagora"),
+      |                                                                                  ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:228:14: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
+  228 |   string_lit("Zemamra"),
+      |              ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:169:26: note: in definition of macro ‘string_lit’
+  169 | #define string_lit(x) { (x), ArrayLength(x) - 1}
+      |                          ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: In function ‘void fill_cities_name_per_index_table()’:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:245:12: warning: statement has no effect [-Wunused-value]
+  245 |     Assert(!cities_name_per_index[city_idx]);
+      |            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:25:21: note: in definition of macro ‘Assert’
+   25 | # define Assert(b) (b)
+      |                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: In function ‘void fill_fruits_name_per_index_table()’:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:256:12: warning: statement has no effect [-Wunused-value]
+  256 |     Assert(!fruits_name_per_index[fruits_idx]);
+      |            ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:25:21: note: in definition of macro ‘Assert’
+   25 | # define Assert(b) (b)
+      |                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: In function ‘void map_file_to_memory(int)’:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:272:22: warning: statement has no effect [-Wunused-value]
+  272 |   Assert(mapped_file != MAP_FAILED);
+      |                      ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:25:21: note: in definition of macro ‘Assert’
+   25 | # define Assert(b) (b)
+      |                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: In function ‘int main()’:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:364:15: warning: statement has no effect [-Wunused-value]
+  364 |     Assert(fd != -1);
+      |               ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:25:21: note: in definition of macro ‘Assert’
+   25 | # define Assert(b) (b)
+      |                     ^
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:404:9: warning: unused variable ‘fruits_cnt’ [-Wunused-variable]
+  404 |     u32 fruits_cnt = 0;
+      |         ^~~~~~~~~~
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp: At global scope:
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:72:13: warning: ‘void end_profiling(int)’ defined but not used [-Wunused-function]
+   72 | static void end_profiling(int i)
+      |             ^~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/sqrt-minus-one/main.cpp:65:13: warning: ‘void start_profiling(int, char*)’ defined but not used [-Wunused-function]
+   65 | static void start_profiling(int i, char *name)
+      |             ^~~~~~~~~~~~~~~
+[2024-03-10T14:13:01Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpccAonY/sol" with exit code: exit status: 0
+[2024-03-10T14:13:01Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336698
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 21.172731ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336714
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.681081ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336730
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.5142ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336746
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.181963ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336762
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 4.996513ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336778
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.4197ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336794
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.355848ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336810
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.244708ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336826
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.614865ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:13:01Z DEBUG blarun] The current started process has pid: 336842
+[2024-03-10T14:13:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:13:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:13:01Z DEBUG blarun] Correctness execution finished in: 5.77481ms
+[2024-03-10T14:13:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:13:01Z DEBUG blarun] Comparing output "/tmp/.tmpsKXS2i/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:13:01Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:13:01Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:13:03Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpccAonY/input.txt"
+[2024-03-10T14:13:03Z DEBUG blarun] Starting execution #0
+[2024-03-10T14:13:03Z DEBUG blarun] The current started process has pid: 336860
+[2024-03-10T14:13:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:14:22Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:14:22Z DEBUG blarun] Execution #0 finished in: 79.077959161s
+[2024-03-10T14:14:22Z DEBUG blarun] Computing verdict using "/tmp/.tmpccAonY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:14:22Z DEBUG blarun] Comparing output "/tmp/.tmpccAonY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:14:22Z DEBUG blarun] Starting execution #1
+[2024-03-10T14:14:22Z DEBUG blarun] The current started process has pid: 336877
+[2024-03-10T14:14:22Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:15:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:15:41Z DEBUG blarun] Execution #1 finished in: 79.015502562s
+[2024-03-10T14:15:41Z DEBUG blarun] Computing verdict using "/tmp/.tmpccAonY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:15:41Z DEBUG blarun] Comparing output "/tmp/.tmpccAonY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:15:41Z DEBUG blarun] Starting execution #2
+[2024-03-10T14:15:41Z DEBUG blarun] The current started process has pid: 336896
+[2024-03-10T14:15:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:17:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:17:00Z DEBUG blarun] Execution #2 finished in: 78.985151272s
+[2024-03-10T14:17:00Z DEBUG blarun] Computing verdict using "/tmp/.tmpccAonY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:17:00Z DEBUG blarun] Comparing output "/tmp/.tmpccAonY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:17:00Z DEBUG blarun] Starting execution #3
+[2024-03-10T14:17:00Z DEBUG blarun] The current started process has pid: 336912
+[2024-03-10T14:17:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:18:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:18:19Z DEBUG blarun] Execution #3 finished in: 78.966395273s
+[2024-03-10T14:18:19Z DEBUG blarun] Computing verdict using "/tmp/.tmpccAonY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:18:19Z DEBUG blarun] Comparing output "/tmp/.tmpccAonY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:18:19Z DEBUG blarun] Starting execution #4
+[2024-03-10T14:18:19Z DEBUG blarun] The current started process has pid: 336938
+[2024-03-10T14:18:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:38Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:38Z DEBUG blarun] Execution #4 finished in: 78.816524292s
+[2024-03-10T14:19:38Z DEBUG blarun] Computing verdict using "/tmp/.tmpccAonY/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:19:38Z DEBUG blarun] Comparing output "/tmp/.tmpccAonY/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:19:38Z INFO  blarun] Submission from user: sqrt-minus-one has finished with verdict: Ac and with an AVG execution time of: 78.989016369s and MED of 78.985151272s
+[2024-03-10T14:19:38Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ElMoulaouiAnouar/index.js"
+[2024-03-10T14:19:38Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:19:38Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ElMoulaouiAnouar/index.js" to "/tmp/.tmpqsDhcZ/main.js"
+[2024-03-10T14:19:38Z DEBUG blarun] The current started process has pid: 336956
+[2024-03-10T14:19:38Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:38Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:38Z DEBUG blarun] Correctness execution finished in: 554.521652ms
+[2024-03-10T14:19:38Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:19:38Z DEBUG blarun] Comparing output "/tmp/.tmpqsDhcZ/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:19:38Z INFO  blarun] Solution comparison failed, output for the solution is: Settat  46254.38000000003 
+    Peach 1.08 
+    Passion_Fruit 1.13 
+    Honeydew 1.21 
+    Rutabaga 1.27 
+    Spinach 1.41 
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:19:38Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:19:38Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:19:38Z INFO  blarun] Submission from user: ElMoulaouiAnouar has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:19:38Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp"
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp: In function ‘Result process_chunk(void*)’:
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:27:39: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+   27 | #define min(a, b) (a ^ ((b ^ a) & -(b < a)));
+      |                                       ^
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:104:42: note: in expansion of macro ‘min’
+  104 |       result->minprodprice[hash][hash2]= min(revh[word],result->minprodprice[hash][hash2] );
+      |                                          ^~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp: In function ‘int main(int, char**)’:
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:260:26: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  260 |         for (int i = 0; i<dig.size(); i++) {
+      |                         ~^~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:261:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  261 |             for (int j=0; j<dig.size(); j++) {
+      |                           ~^~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:267:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  267 |         for (int i=0; i<dig.size(); i++) {
+      |                       ~^~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:268:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  268 |             for (int j=0; j<double_dig.size(); j++) {
+      |                           ~^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:287:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  287 |         for (int i=0; i<double_dig.size(); i++) {
+      |                       ~^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:288:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  288 |             for (int j=0; j<double_dig.size(); j++) {
+      |                           ~^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:299:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  299 |     for (int i=0; i<double_dig.size(); i++) {
+      |                   ~^~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:309:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  309 |         for (int i=0; i<dig.size(); i++) {
+      |                       ~^~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir/solution_swar_driven.cpp:310:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  310 |             for (int j=0; j<dig.size(); j++) {
+      |                           ~^~~~~~~~~~~
+[2024-03-10T14:19:41Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpguPm4S/sol" with exit code: exit status: 0
+[2024-03-10T14:19:41Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:19:41Z DEBUG blarun] The current started process has pid: 336973
+[2024-03-10T14:19:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:42Z DEBUG blarun] Correctness execution finished in: 828.950182ms
+[2024-03-10T14:19:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:19:42Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:19:42Z DEBUG blarun] The current started process has pid: 336990
+[2024-03-10T14:19:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:42Z DEBUG blarun] Correctness execution finished in: 631.867569ms
+[2024-03-10T14:19:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:19:42Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:19:42Z DEBUG blarun] The current started process has pid: 337007
+[2024-03-10T14:19:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:43Z DEBUG blarun] Correctness execution finished in: 606.285953ms
+[2024-03-10T14:19:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:19:43Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:19:43Z DEBUG blarun] The current started process has pid: 337024
+[2024-03-10T14:19:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:43Z DEBUG blarun] Correctness execution finished in: 624.35759ms
+[2024-03-10T14:19:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:19:43Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:19:44Z DEBUG blarun] The current started process has pid: 337041
+[2024-03-10T14:19:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:44Z DEBUG blarun] Correctness execution finished in: 632.015439ms
+[2024-03-10T14:19:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:19:44Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:19:44Z DEBUG blarun] The current started process has pid: 337058
+[2024-03-10T14:19:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:45Z DEBUG blarun] Correctness execution finished in: 629.835873ms
+[2024-03-10T14:19:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:19:45Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:19:45Z DEBUG blarun] The current started process has pid: 337075
+[2024-03-10T14:19:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:45Z DEBUG blarun] Correctness execution finished in: 614.268676ms
+[2024-03-10T14:19:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:19:45Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:19:45Z DEBUG blarun] The current started process has pid: 337092
+[2024-03-10T14:19:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:46Z DEBUG blarun] Correctness execution finished in: 624.545474ms
+[2024-03-10T14:19:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:19:46Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:19:46Z DEBUG blarun] The current started process has pid: 337109
+[2024-03-10T14:19:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:47Z DEBUG blarun] Correctness execution finished in: 614.692316ms
+[2024-03-10T14:19:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:19:47Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:19:47Z DEBUG blarun] The current started process has pid: 337126
+[2024-03-10T14:19:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:19:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:19:47Z DEBUG blarun] Correctness execution finished in: 620.817618ms
+[2024-03-10T14:19:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:19:47Z DEBUG blarun] Comparing output "/tmp/.tmpu9em7O/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:19:47Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:19:47Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:19:49Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpguPm4S/input.txt"
+[2024-03-10T14:19:49Z DEBUG blarun] Starting execution #0
+[2024-03-10T14:19:49Z DEBUG blarun] The current started process has pid: 337145
+[2024-03-10T14:19:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:21:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:21:08Z DEBUG blarun] Execution #0 finished in: 79.69375789s
+[2024-03-10T14:21:08Z DEBUG blarun] Computing verdict using "/tmp/.tmpguPm4S/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:21:08Z DEBUG blarun] Comparing output "/tmp/.tmpguPm4S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:21:08Z DEBUG blarun] Starting execution #1
+[2024-03-10T14:21:08Z DEBUG blarun] The current started process has pid: 337162
+[2024-03-10T14:21:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:22:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:22:28Z DEBUG blarun] Execution #1 finished in: 79.755083617s
+[2024-03-10T14:22:28Z DEBUG blarun] Computing verdict using "/tmp/.tmpguPm4S/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:22:28Z DEBUG blarun] Comparing output "/tmp/.tmpguPm4S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:22:28Z DEBUG blarun] Starting execution #2
+[2024-03-10T14:22:28Z DEBUG blarun] The current started process has pid: 337179
+[2024-03-10T14:22:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:23:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:23:48Z DEBUG blarun] Execution #2 finished in: 79.810052706s
+[2024-03-10T14:23:48Z DEBUG blarun] Computing verdict using "/tmp/.tmpguPm4S/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:23:48Z DEBUG blarun] Comparing output "/tmp/.tmpguPm4S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:23:48Z DEBUG blarun] Starting execution #3
+[2024-03-10T14:23:48Z DEBUG blarun] The current started process has pid: 337196
+[2024-03-10T14:23:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:25:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:25:08Z DEBUG blarun] Execution #3 finished in: 79.81533706s
+[2024-03-10T14:25:08Z DEBUG blarun] Computing verdict using "/tmp/.tmpguPm4S/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:25:08Z DEBUG blarun] Comparing output "/tmp/.tmpguPm4S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:25:08Z DEBUG blarun] Starting execution #4
+[2024-03-10T14:25:08Z DEBUG blarun] The current started process has pid: 337215
+[2024-03-10T14:25:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:28Z DEBUG blarun] Execution #4 finished in: 79.859763104s
+[2024-03-10T14:26:28Z DEBUG blarun] Computing verdict using "/tmp/.tmpguPm4S/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:26:28Z DEBUG blarun] Comparing output "/tmp/.tmpguPm4S/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:26:28Z INFO  blarun] Submission from user: samir has finished with verdict: Ac and with an AVG execution time of: 79.793491127s and MED of 79.810052706s
+[2024-03-10T14:26:28Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/machiyouness/main.c"
+/home/maxheap/blanat/submissions/machiyouness/main.c: In function ‘void put(HashMap*, const char*, float)’:
+/home/maxheap/blanat/submissions/machiyouness/main.c:83:12: warning: ‘char* strncpy(char*, const char*, size_t)’ specified bound 50 equals destination size [-Wstringop-truncation]
+   83 |     strncpy(new_entry->city, city, MAX_CITY_LENGTH);
+      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[2024-03-10T14:26:28Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp9Uerc0/sol" with exit code: exit status: 0
+[2024-03-10T14:26:28Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:26:28Z DEBUG blarun] The current started process has pid: 337239
+[2024-03-10T14:26:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:28Z DEBUG blarun] Correctness execution finished in: 26.287193ms
+[2024-03-10T14:26:28Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:28Z DEBUG blarun] Comparing output "/tmp/.tmpwSAhAq/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:28Z DEBUG blarun] The current started process has pid: 337240
+[2024-03-10T14:26:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:28Z DEBUG blarun] Correctness execution finished in: 26.933158ms
+[2024-03-10T14:26:28Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:26:28Z DEBUG blarun] Comparing output "/tmp/.tmpwSAhAq/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:26:28Z INFO  blarun] Solution comparison failed, output for the solution is: Layoune 45875.00
+    Plum 1.09
+    Rutabaga 1.10
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+     expected output is Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.10
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+    
+[2024-03-10T14:26:28Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:26:28Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:26:28Z INFO  blarun] Submission from user: machiyouness has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:26:28Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/habib94/Main.java"
+Note: /tmp/.tmpWeoRaa/Main.java uses unchecked or unsafe operations.
+Note: Recompile with -Xlint:unchecked for details.
+[2024-03-10T14:26:29Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpWeoRaa/Main.java" with exit code: exit status: 0
+[2024-03-10T14:26:29Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:26:29Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/habib94/Main.java" to "/tmp/.tmpk7Z8mR/Main.java"
+[2024-03-10T14:26:29Z DEBUG blarun] Recompiling Java solution for correctness checks
+Note: /tmp/.tmpk7Z8mR/Main.java uses unchecked or unsafe operations.
+Note: Recompile with -Xlint:unchecked for details.
+[2024-03-10T14:26:30Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpk7Z8mR/Main.java" with exit code: exit status: 0
+[2024-03-10T14:26:30Z DEBUG blarun] The current started process has pid: 337305
+[2024-03-10T14:26:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:30Z DEBUG blarun] Correctness execution finished in: 220.901185ms
+[2024-03-10T14:26:30Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:30Z DEBUG blarun] Comparing output "/tmp/.tmpk7Z8mR/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:30Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:26:30Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:26:30Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:26:30Z INFO  blarun] Submission from user: habib94 has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:26:30Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/alirca68/main.c"
+[2024-03-10T14:26:30Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpK9yYRy/sol" with exit code: exit status: 0
+[2024-03-10T14:26:30Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:26:30Z DEBUG blarun] The current started process has pid: 337379
+[2024-03-10T14:26:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:30Z DEBUG blarun] Correctness execution finished in: 39.820218ms
+[2024-03-10T14:26:30Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:30Z DEBUG blarun] Comparing output "/tmp/.tmpSFlJTH/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:30Z INFO  blarun] Solution comparison failed, output for the solution is: 
+    Ksar_El_Kebir 9.98
+    Goji_Berry 1.07
+    Honeydew 1.54
+    Basil 1.87
+    Dragon_Fruit 2.28
+    Currant 3.22
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:26:30Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:26:30Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:26:30Z INFO  blarun] Submission from user: alirca68 has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:26:30Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/hamzamogni/main.py"
+[2024-03-10T14:26:30Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:26:30Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/hamzamogni/main.py" to "/tmp/.tmpw7WbMN/main.py"
+[2024-03-10T14:26:30Z DEBUG blarun] The current started process has pid: 337380
+[2024-03-10T14:26:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 162.080848ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337411
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 104.670101ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337442
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 108.294882ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337473
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 104.057325ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337504
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 106.087761ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337535
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 106.539316ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337566
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 103.708548ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337597
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 108.223916ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337628
+[2024-03-10T14:26:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:31Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:31Z DEBUG blarun] Correctness execution finished in: 108.38624ms
+[2024-03-10T14:26:31Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:26:31Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:26:31Z DEBUG blarun] The current started process has pid: 337659
+[2024-03-10T14:26:32Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:26:32Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:26:32Z DEBUG blarun] Correctness execution finished in: 104.831045ms
+[2024-03-10T14:26:32Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:26:32Z DEBUG blarun] Comparing output "/tmp/.tmpw7WbMN/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:26:32Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:26:32Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:26:33Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp7V7VhP/input.txt"
+[2024-03-10T14:26:33Z DEBUG blarun] The current started process has pid: 337692
+[2024-03-10T14:26:33Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:39Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:39Z DEBUG blarun] Execution #0 finished in: 126.243426196s
+[2024-03-10T14:28:39Z DEBUG blarun] Comparing output "/tmp/.tmp7V7VhP/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:28:39Z INFO  blarun] Solution comparison failed, output for the solution is: Imzouren 71262458.40
+    Acorn_Squash 1.00
+    Apple 1.00
+    Apricot 1.00
+    Artichoke 1.00
+    Asparagus 1.00
+     expected output is Drarga 499408537.35
+    Acorn_Squash 1.00
+    Apple 1.00
+    Apricot 1.00
+    Artichoke 1.00
+    Asparagus 1.00
+    
+[2024-03-10T14:28:39Z DEBUG blarun] Submission is not correct, aborting further runs
+[2024-03-10T14:28:39Z INFO  blarun] Submission from user: hamzamogni has finished with verdict: Wa and with an AVG execution time of: 126.243426196s and MED of 126.243426196s
+[2024-03-10T14:28:39Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/dauom/main.cpp"
+[2024-03-10T14:28:42Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpo0P4oQ/sol" with exit code: exit status: 0
+[2024-03-10T14:28:42Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:28:42Z DEBUG blarun] The current started process has pid: 337722
+[2024-03-10T14:28:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:42Z DEBUG blarun] Correctness execution finished in: 23.830861ms
+[2024-03-10T14:28:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:28:42Z DEBUG blarun] Comparing output "/tmp/.tmpqbySsC/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:28:42Z INFO  blarun] Solution comparison failed, output for the solution is:  40000000000000000.00
+     0.00
+     0.00
+     0.00
+     0.00
+     0.00
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:28:42Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:28:42Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:28:42Z INFO  blarun] Submission from user: dauom has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:28:42Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/BerqiaMouad/solution.py"
+[2024-03-10T14:28:42Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:28:42Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/BerqiaMouad/solution.py" to "/tmp/.tmpQ6f0kr/main.py"
+[2024-03-10T14:28:42Z DEBUG blarun] The current started process has pid: 337739
+[2024-03-10T14:28:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 166.371409ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337750
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 133.017236ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337761
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 133.678388ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337772
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 130.527061ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337783
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 131.928349ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337794
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:43Z DEBUG blarun] Correctness execution finished in: 129.317877ms
+[2024-03-10T14:28:43Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:28:43Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:28:43Z DEBUG blarun] The current started process has pid: 337805
+[2024-03-10T14:28:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:44Z DEBUG blarun] Correctness execution finished in: 131.460029ms
+[2024-03-10T14:28:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:28:44Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:28:44Z DEBUG blarun] The current started process has pid: 337816
+[2024-03-10T14:28:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:44Z DEBUG blarun] Correctness execution finished in: 132.699842ms
+[2024-03-10T14:28:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:28:44Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:28:44Z DEBUG blarun] The current started process has pid: 337827
+[2024-03-10T14:28:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:44Z DEBUG blarun] Correctness execution finished in: 131.35445ms
+[2024-03-10T14:28:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:28:44Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:28:44Z DEBUG blarun] The current started process has pid: 337838
+[2024-03-10T14:28:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:28:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:28:44Z DEBUG blarun] Correctness execution finished in: 130.879259ms
+[2024-03-10T14:28:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:28:44Z DEBUG blarun] Comparing output "/tmp/.tmpQ6f0kr/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:28:44Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:28:44Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:28:44Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpjFUeMP/input.txt"
+[2024-03-10T14:28:44Z DEBUG blarun] The current started process has pid: 337851
+[2024-03-10T14:28:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:45Z DEBUG blarun] Child process timed out
+[2024-03-10T14:38:45Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T14:38:45Z INFO  blarun] Submission from user: BerqiaMouad has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:38:45Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/izblackcat/Main.java"
+[2024-03-10T14:38:46Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpSSPPdR/Main.java" with exit code: exit status: 0
+[2024-03-10T14:38:46Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:38:46Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/izblackcat/Main.java" to "/tmp/.tmpXSqCNm/Main.java"
+[2024-03-10T14:38:46Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T14:38:47Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpXSqCNm/Main.java" with exit code: exit status: 0
+[2024-03-10T14:38:47Z DEBUG blarun] The current started process has pid: 345072
+[2024-03-10T14:38:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:47Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:47Z DEBUG blarun] Correctness execution finished in: 502.397005ms
+[2024-03-10T14:38:47Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:38:47Z DEBUG blarun] Comparing output "/tmp/.tmpXSqCNm/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:38:47Z DEBUG blarun] The current started process has pid: 345121
+[2024-03-10T14:38:47Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:48Z DEBUG blarun] Correctness execution finished in: 476.064264ms
+[2024-03-10T14:38:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:38:48Z DEBUG blarun] Comparing output "/tmp/.tmpXSqCNm/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:38:48Z INFO  blarun] Solution comparison failed, output for the solution is: Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.1
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+     expected output is Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.10
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+    
+[2024-03-10T14:38:48Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:38:48Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:38:48Z INFO  blarun] Submission from user: izblackcat has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:38:48Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/AbidarYassine/Main.java"
+/tmp/.tmpYKxLwn/Main.java:73: error: class, interface, enum, or record expected
+}
+^
+1 error
+[2024-03-10T14:38:48Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpYKxLwn/Main.java" with exit code: exit status: 1
+[2024-03-10T14:38:48Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/AbidarYassine/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "AbidarYassine" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T14:38:48Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ismail-bertalfilali/Main.java"
+[2024-03-10T14:38:49Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmplu4FM5/Main.java" with exit code: exit status: 0
+[2024-03-10T14:38:49Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:38:49Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ismail-bertalfilali/Main.java" to "/tmp/.tmpnAUPnI/Main.java"
+[2024-03-10T14:38:49Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T14:38:49Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpnAUPnI/Main.java" with exit code: exit status: 0
+[2024-03-10T14:38:49Z DEBUG blarun] The current started process has pid: 345257
+[2024-03-10T14:38:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:50Z DEBUG blarun] Correctness execution finished in: 272.896428ms
+[2024-03-10T14:38:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:38:50Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:38:50Z DEBUG blarun] The current started process has pid: 345300
+[2024-03-10T14:38:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:50Z DEBUG blarun] Correctness execution finished in: 282.329441ms
+[2024-03-10T14:38:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:38:50Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:38:50Z DEBUG blarun] The current started process has pid: 345343
+[2024-03-10T14:38:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:50Z DEBUG blarun] Correctness execution finished in: 284.682624ms
+[2024-03-10T14:38:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:38:50Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:38:50Z DEBUG blarun] The current started process has pid: 345386
+[2024-03-10T14:38:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:50Z DEBUG blarun] Correctness execution finished in: 271.047234ms
+[2024-03-10T14:38:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:38:50Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:38:50Z DEBUG blarun] The current started process has pid: 345430
+[2024-03-10T14:38:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:51Z DEBUG blarun] Correctness execution finished in: 291.779379ms
+[2024-03-10T14:38:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:38:51Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:38:51Z DEBUG blarun] The current started process has pid: 345473
+[2024-03-10T14:38:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:51Z DEBUG blarun] Correctness execution finished in: 264.670216ms
+[2024-03-10T14:38:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:38:51Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:38:51Z DEBUG blarun] The current started process has pid: 345516
+[2024-03-10T14:38:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:51Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:51Z DEBUG blarun] Correctness execution finished in: 271.387719ms
+[2024-03-10T14:38:51Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:38:51Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:38:51Z DEBUG blarun] The current started process has pid: 345560
+[2024-03-10T14:38:51Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:52Z DEBUG blarun] Correctness execution finished in: 263.145002ms
+[2024-03-10T14:38:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:38:52Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:38:52Z DEBUG blarun] The current started process has pid: 345602
+[2024-03-10T14:38:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:52Z DEBUG blarun] Correctness execution finished in: 255.335746ms
+[2024-03-10T14:38:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:38:52Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:38:52Z DEBUG blarun] The current started process has pid: 345645
+[2024-03-10T14:38:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:38:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:38:52Z DEBUG blarun] Correctness execution finished in: 300.124073ms
+[2024-03-10T14:38:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:38:52Z DEBUG blarun] Comparing output "/tmp/.tmpnAUPnI/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:38:52Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:38:52Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:38:52Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmplu4FM5/input.txt"
+[2024-03-10T14:38:52Z DEBUG blarun] Starting execution run #0
+[2024-03-10T14:38:52Z DEBUG blarun] The current started process has pid: 345692
+[2024-03-10T14:38:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:40:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:40:11Z DEBUG blarun] Execution #0 finished in: 79.153841931s
+[2024-03-10T14:40:11Z DEBUG blarun] Computing verdict using "/tmp/.tmplu4FM5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:40:11Z DEBUG blarun] Comparing output "/tmp/.tmplu4FM5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:40:11Z DEBUG blarun] Starting execution run #1
+[2024-03-10T14:40:11Z DEBUG blarun] The current started process has pid: 345776
+[2024-03-10T14:40:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:41:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:41:30Z DEBUG blarun] Execution #1 finished in: 78.619577619s
+[2024-03-10T14:41:30Z DEBUG blarun] Computing verdict using "/tmp/.tmplu4FM5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:41:30Z DEBUG blarun] Comparing output "/tmp/.tmplu4FM5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:41:30Z DEBUG blarun] Starting execution run #2
+[2024-03-10T14:41:30Z DEBUG blarun] The current started process has pid: 345823
+[2024-03-10T14:41:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:42:49Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:42:49Z DEBUG blarun] Execution #2 finished in: 78.603138402s
+[2024-03-10T14:42:49Z DEBUG blarun] Computing verdict using "/tmp/.tmplu4FM5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:42:49Z DEBUG blarun] Comparing output "/tmp/.tmplu4FM5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:42:49Z DEBUG blarun] Starting execution run #3
+[2024-03-10T14:42:49Z DEBUG blarun] The current started process has pid: 345871
+[2024-03-10T14:42:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:44:07Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:44:07Z DEBUG blarun] Execution #3 finished in: 78.607086274s
+[2024-03-10T14:44:07Z DEBUG blarun] Computing verdict using "/tmp/.tmplu4FM5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:44:07Z DEBUG blarun] Comparing output "/tmp/.tmplu4FM5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:44:07Z DEBUG blarun] Starting execution run #4
+[2024-03-10T14:44:07Z DEBUG blarun] The current started process has pid: 345920
+[2024-03-10T14:44:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:26Z DEBUG blarun] Execution #4 finished in: 78.691642677s
+[2024-03-10T14:45:26Z DEBUG blarun] Computing verdict using "/tmp/.tmplu4FM5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:45:26Z DEBUG blarun] Comparing output "/tmp/.tmplu4FM5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:45:26Z INFO  blarun] Submission from user: ismail-bertalfilali has finished with verdict: Ac and with an AVG execution time of: 78.639435523s and MED of 78.619577619s
+[2024-03-10T14:45:26Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ayoubakh/main.py"
+[2024-03-10T14:45:26Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:45:26Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ayoubakh/main.py" to "/tmp/.tmpwsl5qG/main.py"
+[2024-03-10T14:45:26Z DEBUG blarun] The current started process has pid: 345967
+[2024-03-10T14:45:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:26Z DEBUG blarun] Correctness execution finished in: 134.544652ms
+[2024-03-10T14:45:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:26Z DEBUG blarun] Comparing output "/tmp/.tmpwsl5qG/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:26Z INFO  blarun] Solution comparison failed, output for the solution is: Arfoud 763.49
+    Kiwi 1.00
+    Oregano 1.12
+    Plantain 1.12
+    Raspberry 1.17
+    Carrot 1.26
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:45:26Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:45:26Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:45:26Z INFO  blarun] Submission from user: ayoubakh has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:45:26Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/sickerine/solution.rs"
+[2024-03-10T14:45:26Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/sickerine/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "sickerine" } with error: No such file or directory (os error 2)
+[2024-03-10T14:45:26Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/achrafaitibba/Main.java"
+[2024-03-10T14:45:27Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpz03cYU/Main.java" with exit code: exit status: 0
+[2024-03-10T14:45:27Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:45:27Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/achrafaitibba/Main.java" to "/tmp/.tmpjLhQsf/Main.java"
+[2024-03-10T14:45:27Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T14:45:28Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpjLhQsf/Main.java" with exit code: exit status: 0
+[2024-03-10T14:45:28Z DEBUG blarun] The current started process has pid: 346031
+[2024-03-10T14:45:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:28Z DEBUG blarun] Correctness execution finished in: 229.826899ms
+[2024-03-10T14:45:28Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:28Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:28Z DEBUG blarun] The current started process has pid: 346059
+[2024-03-10T14:45:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:28Z DEBUG blarun] Correctness execution finished in: 231.936027ms
+[2024-03-10T14:45:28Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:28Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:28Z DEBUG blarun] The current started process has pid: 346087
+[2024-03-10T14:45:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:28Z DEBUG blarun] Correctness execution finished in: 231.715646ms
+[2024-03-10T14:45:28Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:28Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:28Z DEBUG blarun] The current started process has pid: 346115
+[2024-03-10T14:45:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:29Z DEBUG blarun] Correctness execution finished in: 236.380849ms
+[2024-03-10T14:45:29Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:29Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:29Z DEBUG blarun] The current started process has pid: 346143
+[2024-03-10T14:45:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:29Z DEBUG blarun] Correctness execution finished in: 228.115255ms
+[2024-03-10T14:45:29Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:29Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:29Z DEBUG blarun] The current started process has pid: 346171
+[2024-03-10T14:45:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:29Z DEBUG blarun] Correctness execution finished in: 237.242131ms
+[2024-03-10T14:45:29Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:29Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:29Z DEBUG blarun] The current started process has pid: 346199
+[2024-03-10T14:45:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:29Z DEBUG blarun] Correctness execution finished in: 211.650671ms
+[2024-03-10T14:45:29Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:29Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:29Z DEBUG blarun] The current started process has pid: 346227
+[2024-03-10T14:45:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:29Z DEBUG blarun] Correctness execution finished in: 218.591718ms
+[2024-03-10T14:45:29Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:29Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:29Z DEBUG blarun] The current started process has pid: 346255
+[2024-03-10T14:45:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:30Z DEBUG blarun] Correctness execution finished in: 228.846725ms
+[2024-03-10T14:45:30Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:30Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:30Z DEBUG blarun] The current started process has pid: 346283
+[2024-03-10T14:45:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:30Z DEBUG blarun] Correctness execution finished in: 218.379126ms
+[2024-03-10T14:45:30Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:30Z DEBUG blarun] Comparing output "/tmp/.tmpjLhQsf/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:30Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:45:30Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:45:31Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpz03cYU/input.txt"
+[2024-03-10T14:45:31Z DEBUG blarun] Starting execution run #0
+[2024-03-10T14:45:31Z DEBUG blarun] The current started process has pid: 346313
+[2024-03-10T14:45:31Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
+	at java.base/java.lang.StringUTF16.compress(StringUTF16.java:161)
+	at java.base/java.lang.String.<init>(String.java:4501)
+	at java.base/java.lang.String.<init>(String.java:300)
+	at java.base/java.nio.HeapCharBuffer.toString(HeapCharBuffer.java:653)
+	at java.base/java.nio.CharBuffer.toString(CharBuffer.java:1859)
+	at Main.lambda$main$3(Main.java:50)
+	at Main$$Lambda$2/0x00007f5cd8000a08.accept(Unknown Source)
+	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
+	at Main.main(Main.java:49)
+[2024-03-10T14:45:40Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T14:45:40Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/achrafaitibba/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "achrafaitibba" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T14:45:40Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/YassineOsip/main.py"
+[2024-03-10T14:45:40Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:45:40Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/YassineOsip/main.py" to "/tmp/.tmpqpE3of/main.py"
+[2024-03-10T14:45:40Z DEBUG blarun] The current started process has pid: 346348
+[2024-03-10T14:45:40Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:40Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:40Z DEBUG blarun] Correctness execution finished in: 203.033352ms
+[2024-03-10T14:45:40Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:40Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:40Z DEBUG blarun] The current started process has pid: 346360
+[2024-03-10T14:45:40Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 138.888767ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346372
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 137.286722ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346384
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 136.274539ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346396
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 137.493032ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346408
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 138.302725ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346420
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 139.409406ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346432
+[2024-03-10T14:45:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:41Z DEBUG blarun] Correctness execution finished in: 137.064426ms
+[2024-03-10T14:45:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:41Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:41Z DEBUG blarun] The current started process has pid: 346444
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 137.591849ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346456
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 140.293206ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmpqpE3of/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:42Z INFO  blarun] Solution comparison failed, output for the solution is: Taza 45642.34
+    Pomegranate 1.44
+    Apple 1.52
+    Cantaloupe 1.57
+    Parsnip 2.03
+    Date 2.14
+     expected output is Errachidia 45642.45
+    Mint 1.03
+    Cherry 1.48
+    Dragon_Fruit 1.48
+    Raspberry 1.66
+    Jicama 1.75
+    
+    
+[2024-03-10T14:45:42Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:45:42Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:45:42Z INFO  blarun] Submission from user: YassineOsip has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:45:42Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/superma-C/w_32procs.c"
+[2024-03-10T14:45:42Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpxoizB0/sol" with exit code: exit status: 0
+[2024-03-10T14:45:42Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346473
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 25.547853ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346506
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.148387ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346539
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.15228ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346572
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.278021ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346605
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.116955ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346638
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.902495ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346671
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.214738ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346704
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.194549ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346737
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.162792ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346770
+[2024-03-10T14:45:42Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:45:42Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:45:42Z DEBUG blarun] Correctness execution finished in: 4.208901ms
+[2024-03-10T14:45:42Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:42Z DEBUG blarun] Comparing output "/tmp/.tmprxvvYd/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:45:42Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:45:42Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:45:42Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpxoizB0/input.txt"
+[2024-03-10T14:45:42Z DEBUG blarun] Starting execution #0
+[2024-03-10T14:45:42Z DEBUG blarun] The current started process has pid: 346806
+[2024-03-10T14:45:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:01Z DEBUG blarun] Execution #0 finished in: 78.174804443s
+[2024-03-10T14:47:01Z DEBUG blarun] Computing verdict using "/tmp/.tmpxoizB0/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:01Z DEBUG blarun] Comparing output "/tmp/.tmpxoizB0/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:01Z DEBUG blarun] Starting execution #1
+[2024-03-10T14:47:01Z DEBUG blarun] The current started process has pid: 346841
+[2024-03-10T14:47:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:05Z DEBUG blarun] Execution #1 finished in: 4.094881389s
+[2024-03-10T14:47:05Z DEBUG blarun] Computing verdict using "/tmp/.tmpxoizB0/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:05Z DEBUG blarun] Comparing output "/tmp/.tmpxoizB0/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:05Z DEBUG blarun] Starting execution #2
+[2024-03-10T14:47:05Z DEBUG blarun] The current started process has pid: 346874
+[2024-03-10T14:47:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:08Z DEBUG blarun] Execution #2 finished in: 3.337442035s
+[2024-03-10T14:47:08Z DEBUG blarun] Computing verdict using "/tmp/.tmpxoizB0/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:08Z DEBUG blarun] Comparing output "/tmp/.tmpxoizB0/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:08Z DEBUG blarun] Starting execution #3
+[2024-03-10T14:47:08Z DEBUG blarun] The current started process has pid: 346907
+[2024-03-10T14:47:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:11Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:11Z DEBUG blarun] Execution #3 finished in: 3.358502584s
+[2024-03-10T14:47:11Z DEBUG blarun] Computing verdict using "/tmp/.tmpxoizB0/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:11Z DEBUG blarun] Comparing output "/tmp/.tmpxoizB0/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:11Z DEBUG blarun] Starting execution #4
+[2024-03-10T14:47:11Z DEBUG blarun] The current started process has pid: 346940
+[2024-03-10T14:47:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:15Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:15Z DEBUG blarun] Execution #4 finished in: 3.362942498s
+[2024-03-10T14:47:15Z DEBUG blarun] Computing verdict using "/tmp/.tmpxoizB0/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:15Z DEBUG blarun] Comparing output "/tmp/.tmpxoizB0/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T14:47:15Z INFO  blarun] Submission from user: superma-C has finished with verdict: Ac and with an AVG execution time of: 3.605442157s and MED of 3.362942498s
+[2024-03-10T14:47:15Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/KABILA-Anas/solution.cpp"
+[2024-03-10T14:47:16Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp85ZffA/sol" with exit code: exit status: 0
+[2024-03-10T14:47:16Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:47:16Z DEBUG blarun] The current started process has pid: 346978
+[2024-03-10T14:47:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:16Z DEBUG blarun] Correctness execution finished in: 95.953598ms
+[2024-03-10T14:47:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:47:16Z DEBUG blarun] Comparing output "/tmp/.tmpeKDeGI/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:47:16Z INFO  blarun] Solution comparison failed, output for the solution is:  191.93
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:47:16Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:47:16Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:47:16Z INFO  blarun] Submission from user: KABILA-Anas has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:47:16Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ettalha0x/main.cpp"
+[2024-03-10T14:47:18Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpNeikZk/sol" with exit code: exit status: 0
+[2024-03-10T14:47:18Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346984
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:18Z DEBUG blarun] Correctness execution finished in: 125.753806ms
+[2024-03-10T14:47:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:47:18Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346985
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:18Z DEBUG blarun] Correctness execution finished in: 126.089546ms
+[2024-03-10T14:47:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:47:18Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346986
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:18Z DEBUG blarun] Correctness execution finished in: 125.868972ms
+[2024-03-10T14:47:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:47:18Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346987
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:18Z DEBUG blarun] Correctness execution finished in: 125.844312ms
+[2024-03-10T14:47:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:47:18Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346988
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:18Z DEBUG blarun] Correctness execution finished in: 125.744233ms
+[2024-03-10T14:47:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:47:18Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:47:18Z DEBUG blarun] The current started process has pid: 346989
+[2024-03-10T14:47:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:19Z DEBUG blarun] Correctness execution finished in: 126.215866ms
+[2024-03-10T14:47:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:47:19Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:47:19Z DEBUG blarun] The current started process has pid: 346990
+[2024-03-10T14:47:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:19Z DEBUG blarun] Correctness execution finished in: 130.257867ms
+[2024-03-10T14:47:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:47:19Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:47:19Z DEBUG blarun] The current started process has pid: 346991
+[2024-03-10T14:47:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:19Z DEBUG blarun] Correctness execution finished in: 125.847981ms
+[2024-03-10T14:47:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:47:19Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:47:19Z DEBUG blarun] The current started process has pid: 346992
+[2024-03-10T14:47:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:19Z DEBUG blarun] Correctness execution finished in: 125.901911ms
+[2024-03-10T14:47:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:47:19Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:47:19Z DEBUG blarun] The current started process has pid: 346993
+[2024-03-10T14:47:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:47:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:47:19Z DEBUG blarun] Correctness execution finished in: 125.554964ms
+[2024-03-10T14:47:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:47:19Z DEBUG blarun] Comparing output "/tmp/.tmpW8cFgN/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:47:19Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:47:19Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:47:21Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpNeikZk/input.txt"
+[2024-03-10T14:47:21Z DEBUG blarun] Starting execution #0
+[2024-03-10T14:47:21Z DEBUG blarun] The current started process has pid: 346996
+[2024-03-10T14:47:21Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:21Z DEBUG blarun] Child process timed out
+[2024-03-10T14:57:21Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T14:57:21Z INFO  blarun] Submission from user: ettalha0x has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:57:21Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/viierr/main.cpp"
+/home/maxheap/blanat/submissions/viierr/main.cpp: In function ‘std::pair<std::basic_string_view<char>, long unsigned int> get_city_results()’:
+/home/maxheap/blanat/submissions/viierr/main.cpp:161:12: warning: unused variable ‘err_c’ [-Wunused-variable]
+  161 |     size_t err_c = 0;
+      |            ^~~~~
+[2024-03-10T14:57:22Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpmJJNtz/sol" with exit code: exit status: 0
+[2024-03-10T14:57:22Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:57:22Z DEBUG blarun] The current started process has pid: 347012
+[2024-03-10T14:57:22Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:22Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:22Z DEBUG blarun] Correctness execution finished in: 44.082336ms
+[2024-03-10T14:57:22Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:57:22Z DEBUG blarun] Comparing output "/tmp/.tmpb63BuV/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:57:22Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Chard 1.00
+    Kiwi 1.00
+    Acorn_Squash 1.01
+    Artichoke 1.01
+    Grapefruit 1.01
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:57:22Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:57:22Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:57:22Z INFO  blarun] Submission from user: viierr has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:57:22Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/bekkaoui99/Main.java"
+[2024-03-10T14:57:23Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpMokSkW/Main.java" with exit code: exit status: 0
+[2024-03-10T14:57:23Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:57:23Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/bekkaoui99/Main.java" to "/tmp/.tmpnpqVz1/Main.java"
+[2024-03-10T14:57:23Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T14:57:24Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpnpqVz1/Main.java" with exit code: exit status: 0
+[2024-03-10T14:57:24Z DEBUG blarun] The current started process has pid: 347092
+[2024-03-10T14:57:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:24Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:24Z DEBUG blarun] Correctness execution finished in: 351.711289ms
+[2024-03-10T14:57:24Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:57:24Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:57:24Z DEBUG blarun] The current started process has pid: 347131
+[2024-03-10T14:57:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:24Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:24Z DEBUG blarun] Correctness execution finished in: 351.830478ms
+[2024-03-10T14:57:24Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:57:24Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:57:24Z DEBUG blarun] The current started process has pid: 347170
+[2024-03-10T14:57:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:25Z DEBUG blarun] Correctness execution finished in: 348.380452ms
+[2024-03-10T14:57:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:57:25Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:57:25Z DEBUG blarun] The current started process has pid: 347209
+[2024-03-10T14:57:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:25Z DEBUG blarun] Correctness execution finished in: 358.453297ms
+[2024-03-10T14:57:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:57:25Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:57:25Z DEBUG blarun] The current started process has pid: 347248
+[2024-03-10T14:57:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:25Z DEBUG blarun] Correctness execution finished in: 332.956427ms
+[2024-03-10T14:57:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:57:25Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:57:25Z DEBUG blarun] The current started process has pid: 347287
+[2024-03-10T14:57:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:26Z DEBUG blarun] Correctness execution finished in: 343.504754ms
+[2024-03-10T14:57:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:57:26Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:57:26Z DEBUG blarun] The current started process has pid: 347326
+[2024-03-10T14:57:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:26Z DEBUG blarun] Correctness execution finished in: 338.902317ms
+[2024-03-10T14:57:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:57:26Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:57:26Z DEBUG blarun] The current started process has pid: 347365
+[2024-03-10T14:57:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:26Z DEBUG blarun] Correctness execution finished in: 332.395359ms
+[2024-03-10T14:57:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:57:26Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:57:26Z DEBUG blarun] The current started process has pid: 347404
+[2024-03-10T14:57:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:27Z DEBUG blarun] Correctness execution finished in: 387.74859ms
+[2024-03-10T14:57:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:57:27Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:57:27Z DEBUG blarun] The current started process has pid: 347443
+[2024-03-10T14:57:27Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:57:27Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:57:27Z DEBUG blarun] Correctness execution finished in: 339.863057ms
+[2024-03-10T14:57:27Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:57:27Z DEBUG blarun] Comparing output "/tmp/.tmpnpqVz1/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:57:27Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:57:27Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:57:28Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpMokSkW/input.txt"
+[2024-03-10T14:57:28Z DEBUG blarun] Starting execution run #0
+[2024-03-10T14:57:28Z DEBUG blarun] The current started process has pid: 347484
+[2024-03-10T14:57:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "main" java.lang.OutOfMemoryError
+	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
+	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
+	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
+	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
+	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
+	at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:564)
+	at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:591)
+	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:689)
+	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159)
+	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173)
+	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
+	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
+	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:765)
+	at Main.main(Main.java:125)
+Caused by: java.lang.OutOfMemoryError: Java heap space
+	at Main.collectingDataV2(Main.java:160)
+	at Main.lambda$main$0(Main.java:130)
+	at Main$$Lambda$2/0x00007f8df8000c38.accept(Unknown Source)
+	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
+	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
+	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
+	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
+	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
+	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
+	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
+	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
+	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
+	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
+[2024-03-10T14:59:50Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T14:59:50Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/bekkaoui99/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "bekkaoui99" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T14:59:50Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Touil-Ali/index.js"
+[2024-03-10T14:59:50Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:59:50Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Touil-Ali/index.js" to "/tmp/.tmphtCazD/main.js"
+[2024-03-10T14:59:50Z DEBUG blarun] The current started process has pid: 347559
+[2024-03-10T14:59:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:50Z DEBUG blarun] Correctness execution finished in: 606.685489ms
+[2024-03-10T14:59:50Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:59:50Z DEBUG blarun] Comparing output "/tmp/.tmphtCazD/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:59:50Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    Mango 1.61
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T14:59:50Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T14:59:50Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T14:59:50Z INFO  blarun] Submission from user: Touil-Ali has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T14:59:50Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Moohaa/Main.java"
+[2024-03-10T14:59:51Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp2vRIJK/Main.java" with exit code: exit status: 0
+[2024-03-10T14:59:51Z INFO  blarun] Starting correctness checks
+[2024-03-10T14:59:51Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Moohaa/Main.java" to "/tmp/.tmpUhtoU3/Main.java"
+[2024-03-10T14:59:51Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T14:59:52Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpUhtoU3/Main.java" with exit code: exit status: 0
+[2024-03-10T14:59:52Z DEBUG blarun] The current started process has pid: 347634
+[2024-03-10T14:59:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:52Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:52Z DEBUG blarun] Correctness execution finished in: 397.983635ms
+[2024-03-10T14:59:52Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:59:52Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T14:59:52Z DEBUG blarun] The current started process has pid: 347693
+[2024-03-10T14:59:52Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:53Z DEBUG blarun] Correctness execution finished in: 354.964527ms
+[2024-03-10T14:59:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:59:53Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T14:59:53Z DEBUG blarun] The current started process has pid: 347752
+[2024-03-10T14:59:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:53Z DEBUG blarun] Correctness execution finished in: 357.471723ms
+[2024-03-10T14:59:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:59:53Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T14:59:53Z DEBUG blarun] The current started process has pid: 347811
+[2024-03-10T14:59:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:53Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:53Z DEBUG blarun] Correctness execution finished in: 381.116108ms
+[2024-03-10T14:59:53Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:59:53Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T14:59:53Z DEBUG blarun] The current started process has pid: 347870
+[2024-03-10T14:59:53Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:54Z DEBUG blarun] Correctness execution finished in: 361.519749ms
+[2024-03-10T14:59:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:59:54Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T14:59:54Z DEBUG blarun] The current started process has pid: 347929
+[2024-03-10T14:59:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:54Z DEBUG blarun] Correctness execution finished in: 352.011487ms
+[2024-03-10T14:59:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:59:54Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T14:59:54Z DEBUG blarun] The current started process has pid: 347989
+[2024-03-10T14:59:54Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:54Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:54Z DEBUG blarun] Correctness execution finished in: 333.556325ms
+[2024-03-10T14:59:54Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:59:54Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T14:59:54Z DEBUG blarun] The current started process has pid: 348048
+[2024-03-10T14:59:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:55Z DEBUG blarun] Correctness execution finished in: 370.508401ms
+[2024-03-10T14:59:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:59:55Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T14:59:55Z DEBUG blarun] The current started process has pid: 348107
+[2024-03-10T14:59:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:55Z DEBUG blarun] Correctness execution finished in: 362.174939ms
+[2024-03-10T14:59:55Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:59:55Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T14:59:55Z DEBUG blarun] The current started process has pid: 348166
+[2024-03-10T14:59:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T14:59:56Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T14:59:56Z DEBUG blarun] Correctness execution finished in: 360.984864ms
+[2024-03-10T14:59:56Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:59:56Z DEBUG blarun] Comparing output "/tmp/.tmpUhtoU3/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T14:59:56Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T14:59:56Z INFO  blarun] Dropping the file cache
+[2024-03-10T14:59:56Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp2vRIJK/input.txt"
+[2024-03-10T14:59:56Z DEBUG blarun] Starting execution run #0
+[2024-03-10T14:59:56Z DEBUG blarun] The current started process has pid: 348228
+[2024-03-10T14:59:56Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:02:50Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:02:50Z DEBUG blarun] Execution #0 finished in: 174.65253184s
+[2024-03-10T15:02:50Z DEBUG blarun] Computing verdict using "/tmp/.tmp2vRIJK/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:02:50Z DEBUG blarun] Comparing output "/tmp/.tmp2vRIJK/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:02:50Z DEBUG blarun] Starting execution run #1
+[2024-03-10T15:02:50Z DEBUG blarun] The current started process has pid: 348291
+[2024-03-10T15:02:50Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:05:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:05:46Z DEBUG blarun] Execution #1 finished in: 175.511199113s
+[2024-03-10T15:05:46Z DEBUG blarun] Computing verdict using "/tmp/.tmp2vRIJK/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:05:46Z DEBUG blarun] Comparing output "/tmp/.tmp2vRIJK/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:05:46Z DEBUG blarun] Starting execution run #2
+[2024-03-10T15:05:46Z DEBUG blarun] The current started process has pid: 348348
+[2024-03-10T15:05:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:08:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:08:41Z DEBUG blarun] Execution #2 finished in: 174.941754655s
+[2024-03-10T15:08:41Z DEBUG blarun] Computing verdict using "/tmp/.tmp2vRIJK/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:08:41Z DEBUG blarun] Comparing output "/tmp/.tmp2vRIJK/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:08:41Z DEBUG blarun] Starting execution run #3
+[2024-03-10T15:08:41Z DEBUG blarun] The current started process has pid: 348408
+[2024-03-10T15:08:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:11:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:11:43Z DEBUG blarun] Execution #3 finished in: 181.771254748s
+[2024-03-10T15:11:43Z DEBUG blarun] Computing verdict using "/tmp/.tmp2vRIJK/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:11:43Z DEBUG blarun] Comparing output "/tmp/.tmp2vRIJK/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:11:43Z DEBUG blarun] Starting execution run #4
+[2024-03-10T15:11:43Z DEBUG blarun] The current started process has pid: 348505
+[2024-03-10T15:11:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:43Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:43Z DEBUG blarun] Execution #4 finished in: 180.837992059s
+[2024-03-10T15:14:43Z DEBUG blarun] Computing verdict using "/tmp/.tmp2vRIJK/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:14:43Z DEBUG blarun] Comparing output "/tmp/.tmp2vRIJK/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:14:43Z INFO  blarun] Submission from user: Moohaa has finished with verdict: Ac and with an AVG execution time of: 177.096981942s and MED of 175.511199113s
+[2024-03-10T15:14:43Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ismailtlem/gblabla_coding_challenge.py"
+[2024-03-10T15:14:43Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:14:43Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ismailtlem/gblabla_coding_challenge.py" to "/tmp/.tmptsxLrS/main.py"
+[2024-03-10T15:14:43Z DEBUG blarun] The current started process has pid: 348562
+[2024-03-10T15:14:43Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 114.704591ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348563
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 90.774271ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348564
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 88.461186ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348565
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 88.785886ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348566
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 89.664858ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348567
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 89.490263ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348568
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 90.699727ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348569
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 89.535235ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348570
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 89.597858ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:14:44Z DEBUG blarun] The current started process has pid: 348571
+[2024-03-10T15:14:44Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:14:44Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:14:44Z DEBUG blarun] Correctness execution finished in: 89.281184ms
+[2024-03-10T15:14:44Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:14:44Z DEBUG blarun] Comparing output "/tmp/.tmptsxLrS/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:14:44Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:14:44Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:14:46Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpXsNlKm/input.txt"
+[2024-03-10T15:14:46Z DEBUG blarun] The current started process has pid: 348574
+[2024-03-10T15:14:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:46Z DEBUG blarun] Child process timed out
+[2024-03-10T15:24:46Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T15:24:46Z INFO  blarun] Submission from user: ismailtlem has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:24:46Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/samir-/main.cpp"
+/home/maxheap/blanat/submissions/samir-/main.cpp: In function ‘int process(int, char**)’:
+/home/maxheap/blanat/submissions/samir-/main.cpp:136:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  136 |     for (int i =0; i<moroccan_cities.size(); i++) {
+      |                    ~^~~~~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp:163:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::__cxx11::basic_string<char> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
+  163 |     for (int i =0; i<vigies.size(); i++) {
+      |                    ~^~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp:175:25: warning: unused variable ‘results’ [-Wunused-variable]
+  175 |     struct OutputChunk *results[THREADS];
+      |                         ^~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp:186:25: warning: unused variable ‘result11’ [-Wunused-variable]
+  186 |     struct OutputChunk *result11;
+      |                         ^~~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp: In function ‘void handleSignal(int)’:
+/home/maxheap/blanat/submissions/samir-/main.cpp:233:19: error: ‘SIGUSR1’ was not declared in this scope
+  233 |     if (signum == SIGUSR1) {
+      |                   ^~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp: In function ‘int main(int, char**)’:
+/home/maxheap/blanat/submissions/samir-/main.cpp:239:12: error: ‘SIGUSR1’ was not declared in this scope
+  239 |     signal(SIGUSR1, handleSignal);
+      |            ^~~~~~~
+/home/maxheap/blanat/submissions/samir-/main.cpp:239:5: error: ‘signal’ was not declared in this scope; did you mean ‘signed’?
+  239 |     signal(SIGUSR1, handleSignal);
+      |     ^~~~~~
+      |     signed
+/home/maxheap/blanat/submissions/samir-/main.cpp:245:7: error: ‘waitpid’ was not declared in this scope
+  245 |       waitpid(pid, &status, 0);
+      |       ^~~~~~~
+[2024-03-10T15:24:47Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpbdBY6Q/sol" with exit code: exit status: 1
+[2024-03-10T15:24:47Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/samir-/main.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "samir-" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T15:24:47Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/elkaddaoui/solution.c"
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:6:1: error: ‘::main’ must return ‘int’
+    6 | void main() {
+      | ^~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c: In function ‘int main()’:
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:13:31: error: invalid conversion from ‘void*’ to ‘char (*)[50]’ [-fpermissive]
+   13 |     char (*citys)[50] = malloc(size * sizeof(*citys));
+      |                         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+      |                               |
+      |                               void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:14:26: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+   14 |     float *price = malloc(size * sizeof(*price));
+      |                    ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+      |                          |
+      |                          void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:35:32: error: invalid conversion from ‘void*’ to ‘char (*)[50]’ [-fpermissive]
+   35 |                 citys = realloc(citys, size * sizeof(*citys));
+      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                |
+      |                                void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:36:32: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+   36 |                 price = realloc(price, size * sizeof(*price));
+      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                |
+      |                                void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:57:33: error: invalid conversion from ‘void*’ to ‘char (*)[50]’ [-fpermissive]
+   57 |     char (*citypro)[50] = malloc(psize * sizeof(*citypro));
+      |                           ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                 |
+      |                                 void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:58:27: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+   58 |     float *pprice = malloc(psize * sizeof(*pprice));
+      |                     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
+      |                           |
+      |                           void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:66:30: error: invalid conversion from ‘void*’ to ‘char (*)[50]’ [-fpermissive]
+   66 |             citypro = realloc(citypro, psize * sizeof(*citypro));
+      |                       ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                              |
+      |                              void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:67:29: error: invalid conversion from ‘void*’ to ‘float*’ [-fpermissive]
+   67 |             pprice = realloc(pprice, psize * sizeof(*pprice));
+      |                      ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                             |
+      |                             void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:111:36: error: invalid conversion from ‘void*’ to ‘char (*)[50]’ [-fpermissive]
+  111 |     char (*sort_queue)[50] = malloc(10 * sizeof(*sort_queue));
+      |                              ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                    |
+      |                                    void*
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:114:19: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  114 |     while (nbr_eq < sizeof(sort_queue)) {
+      |            ~~~~~~~^~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:115:26: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  115 |         for(int dbs=0;dbs<sizeof(sort_queue);dbs++){
+      |                       ~~~^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:122:32: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  122 |         for (q = 0; nbr_eq + q < sizeof(sort_queue); q++) {
+      |                     ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:132:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  132 |         for(int d=0;d<sizeof(sort_queue);d++){
+      |                     ~^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:133:28: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
+  133 |             for(int b=d+1;b<sizeof(sort_queue);b++){
+      |                           ~^~~~~~~~~~~~~~~~~~~
+/home/maxheap/blanat/submissions/elkaddaoui/solution.c:79:11: warning: unused variable ‘min_pprice’ [-Wunused-variable]
+   79 |     float min_pprice = 10000;
+      |           ^~~~~~~~~~
+[2024-03-10T15:24:47Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp4EaoZq/sol" with exit code: exit status: 1
+[2024-03-10T15:24:47Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/elkaddaoui/solution.c", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "elkaddaoui" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T15:24:47Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ouakki/main.go"
+[2024-03-10T15:24:48Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpQxFzoO/sol" with exit code: exit status: 0
+[2024-03-10T15:24:48Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348768
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 43.121842ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348780
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 8.789995ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348791
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 22.646832ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348804
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 7.254266ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348814
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 7.029288ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348825
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 7.633379ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348838
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 7.250698ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348850
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 11.639213ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348862
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 7.061917ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:24:48Z DEBUG blarun] The current started process has pid: 348873
+[2024-03-10T15:24:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:48Z DEBUG blarun] Correctness execution finished in: 8.325699ms
+[2024-03-10T15:24:48Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:24:48Z DEBUG blarun] Comparing output "/tmp/.tmpBGds5Y/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:24:48Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:24:48Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:24:49Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpQxFzoO/input.txt"
+[2024-03-10T15:24:49Z DEBUG blarun] Starting execution #0
+[2024-03-10T15:24:49Z DEBUG blarun] The current started process has pid: 348888
+[2024-03-10T15:24:49Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+panic: runtime error: index out of range [66948294] with length 66948286
+
+goroutine 48 [running]:
+main.(*task).run(0x98b85d0)
+	/home/maxheap/blanat/submissions/ouakki/main.go:126 +0x3f1
+main.main.func1()
+	/home/maxheap/blanat/submissions/ouakki/main.go:282 +0x5c
+created by main.main in goroutine 1
+	/home/maxheap/blanat/submissions/ouakki/main.go:280 +0x2a6
+[2024-03-10T15:24:56Z INFO  blarun] Finished execution of the solution with status: Some(2)
+[2024-03-10T15:24:56Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/ouakki/main.go", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "ouakki" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T15:24:56Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/RedOne KaiTo/main.go"
+[2024-03-10T15:24:57Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpos4QzC/sol" with exit code: exit status: 0
+[2024-03-10T15:24:57Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:24:57Z DEBUG blarun] The current started process has pid: 349070
+[2024-03-10T15:24:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:57Z DEBUG blarun] Correctness execution finished in: 110.944087ms
+[2024-03-10T15:24:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:57Z DEBUG blarun] Comparing output "/tmp/.tmpaMCyaX/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:57Z INFO  blarun] Solution comparison failed, output for the solution is: Taourirt 51174.92
+    Peas 496.75
+    Sage 467.76
+    Pear 295.16
+    Guava 552.01
+    Jicama 471.39
+    Dill 368.01
+    Butternut_Squash 172.90
+    Fig 743.23
+    Thyme 452.49
+    Cantaloupe 1052.46
+    Yam 245.41
+    Collard_Greens 486.34
+    Strawberry 456.78
+    Bok_Choy 324.77
+    Currant 566.61
+    Rhubarb 315.08
+    Parsnip 272.69
+    Papaya 354.72
+    Mango 659.32
+    Carrot 447.18
+    Sweet_Potato 357.62
+    Parsley 881.78
+    Lime 602.69
+    Dragon_Fruit 724.98
+    Oregano 511.66
+    Jackfruit 484.23
+    Orange 699.21
+    Kiwano 174.28
+    Lemon 725.53
+    Cherry 239.10
+    Cranberry 709.40
+    Passion_Fruit 506.11
+    Squash_Blossom 496.13
+    Raspberry 211.59
+    Grapes 530.97
+    Asparagus 913.40
+    Cauliflower 688.33
+    Broccoli 787.79
+    Celery 606.44
+    Salsify 607.79
+    Radish 385.84
+    Rosemary 429.66
+    Eggplant 381.79
+    Persimmon 866.95
+    Watercress 760.71
+    Blueberry 497.21
+    Tomato 445.05
+    Pomegranate 1030.03
+    Lettuce 556.80
+    Honeydew 814.42
+    Artichoke 1244.40
+    Grapefruit 510.57
+    Pineapple 437.59
+    Goji_Berry 902.73
+    Rutabaga 412.01
+    Mint 463.32
+    Peach 337.44
+    Coconut 1070.00
+    Avocado 620.09
+    Endive 576.44
+    Potato 532.10
+    Apple 575.79
+    Date 400.69
+    Acorn_Squash 415.80
+    Chard 495.15
+    Nectarine 523.63
+    Zucchini 485.53
+    Green_Beans 513.59
+    Onion 506.30
+    Plantain 469.50
+    Spinach 542.93
+    Bell_Pepper 300.95
+    Pumpkin 424.32
+    Banana 823.68
+    Garlic 182.88
+    Watermelon 450.45
+    Cactus_Pear 828.82
+    Beet 154.76
+    Kiwi 398.62
+    Apricot 582.39
+    Clementine 658.62
+    Starfruit 836.47
+    Okra 540.02
+    Cucumber 582.51
+    Cabbage 587.73
+    Blackberry 940.78
+    Ginger 556.52
+    Brussels_Sprouts 326.12
+    Kohlrabi 748.94
+    Plum 438.65
+    Cilantro 537.09
+    Basil 368.64
+    Turnip 603.79
+    Kale 438.02
+    Sidi_Kacem 49586.33
+    Goji_Berry 476.50
+    Turnip 578.02
+    Collard_Greens 159.48
+    Spinach 195.81
+    Cauliflower 419.72
+    Cucumber 230.90
+    Zucchini 811.37
+    Peas 430.62
+    Peach 616.70
+    Clementine 623.88
+    Strawberry 350.70
+    Celery 482.88
+    Pumpkin 477.08
+    Sage 364.10
+    Okra 374.04
+    Nectarine 234.07
+    Sweet_Potato 419.99
+    Garlic 520.22
+    Dill 338.24
+    Broccoli 543.70
+    Dragon_Fruit 269.33
+    Coconut 651.65
+    Mango 526.93
+    Eggplant 934.21
+    Jicama 897.29
+    Lime 672.22
+    Fig 596.11
+    Watermelon 475.28
+    Starfruit 682.48
+    Thyme 740.90
+    Plum 585.55
+    Endive 612.40
+    Rosemary 445.43
+    Honeydew 731.02
+    Oregano 426.48
+    Rutabaga 541.49
+    Parsley 727.92
+    Blackberry 564.97
+    Brussels_Sprouts 484.58
+    Banana 433.09
+    Bok_Choy 377.58
+    Avocado 451.47
+    Beet 348.90
+    Tomato 655.81
+    Cranberry 1206.90
+    Kiwi 436.35
+    Squash_Blossom 427.35
+    Jackfruit 519.66
+    Cherry 577.70
+    Grapes 444.66
+    Rhubarb 539.32
+    Chard 567.77
+    Acorn_Squash 374.20
+    Salsify 522.41
+    Kale 421.90
+    Apricot 603.60
+    Grapefruit 159.84
+    Raspberry 718.97
+    Pineapple 290.07
+    Cactus_Pear 654.48
+    Lettuce 315.23
+    Pear 450.63
+    Passion_Fruit 385.73
+    Butternut_Squash 152.60
+    Basil 266.73
+    Cantaloupe 1319.80
+    Carrot 486.20
+    Onion 579.72
+    Apple 472.47
+    Radish 454.77
+    Kiwano 581.84
+    Yam 494.56
+    Lemon 370.22
+    Mint 1061.11
+    Persimmon 228.02
+    Bell_Pepper 693.56
+    Artichoke 783.57
+    Cabbage 863.61
+    Asparagus 587.76
+    Pomegranate 1389.44
+    Currant 540.73
+    Guava 487.50
+    Parsnip 392.93
+    Papaya 708.44
+    Kohlrabi 471.82
+    Watercress 394.47
+    Plantain 531.69
+    Date 463.72
+    Orange 317.94
+    Cilantro 404.06
+    Ginger 413.31
+    Potato 740.61
+    Green_Beans 524.19
+    Blueberry 311.06
+    Ait_Melloul 46463.63
+    Peach 890.98
+    Yam 372.81
+    Kiwano 585.60
+    Guava 610.77
+    Tomato 644.24
+    Broccoli 492.78
+    Grapefruit 387.88
+    Brussels_Sprouts 503.50
+    Rhubarb 647.50
+    Cantaloupe 1028.07
+    Apple 582.64
+    Artichoke 530.02
+    Zucchini 286.86
+    Peas 233.95
+    Fig 394.49
+    Honeydew 648.92
+    Sage 526.74
+    Pear 725.96
+    Onion 535.25
+    Acorn_Squash 409.69
+    Squash_Blossom 569.39
+    Dill 545.77
+    Eggplant 703.18
+    Carrot 317.91
+    Rutabaga 642.29
+    Banana 558.96
+    Cauliflower 309.90
+    Watercress 358.46
+    Cherry 318.75
+    Clementine 511.87
+    Parsley 608.47
+    Coconut 694.19
+    Avocado 434.26
+    Plantain 277.94
+    Thyme 452.53
+    Basil 458.02
+    Butternut_Squash 515.45
+    Lime 209.75
+    Garlic 464.04
+    Nectarine 171.95
+    Parsnip 675.03
+    Plum 426.65
+    Sweet_Potato 458.23
+    Lettuce 695.74
+    Collard_Greens 323.68
+    Turnip 332.19
+    Dragon_Fruit 645.08
+    Cilantro 196.74
+    Pineapple 409.92
+    Green_Beans 518.24
+    Celery 525.54
+    Lemon 448.86
+    Mint 401.33
+    Pumpkin 200.92
+    Persimmon 270.29
+    Radish 650.74
+    Strawberry 388.76
+    Asparagus 412.11
+    Date 530.70
+    Chard 295.40
+    Goji_Berry 412.92
+    Bok_Choy 633.85
+    Cranberry 867.88
+    Papaya 136.38
+    Orange 353.08
+    Passion_Fruit 95.52
+    Blackberry 591.88
+    Blueberry 414.28
+    Beet 692.08
+    Raspberry 518.42
+    Ginger 493.90
+    Mango 532.17
+    Oregano 573.72
+    Cucumber 473.99
+    Currant 632.21
+    Rosemary 560.57
+    Grapes 757.22
+    Jackfruit 611.18
+    Okra 583.87
+    Salsify 42.09
+    Kohlrabi 688.70
+    Pomegranate 1147.38
+    Bell_Pepper 430.88
+    Cactus_Pear 526.53
+    Cabbage 798.86
+    Watermelon 882.64
+    Potato 439.22
+    Spinach 708.98
+    Kale 450.84
+    Jicama 117.38
+    Kiwi 462.86
+    Starfruit 293.66
+    Apricot 371.86
+    Endive 198.75
+    Fes 46801.28
+    Cabbage 827.70
+    Dill 519.84
+    Cucumber 256.83
+    Dragon_Fruit 325.24
+    Grapes 452.16
+    Cantaloupe 1288.93
+    Strawberry 611.97
+    Kohlrabi 601.80
+    Potato 609.80
+    Plantain 294.07
+    Parsley 303.67
+    Currant 450.46
+    Peas 425.13
+    Rhubarb 265.38
+    Basil 407.23
+    Lemon 620.81
+    Endive 292.63
+    Kale 221.65
+    Blueberry 296.32
+    Turnip 280.59
+    Jackfruit 535.98
+    Watermelon 693.18
+    Asparagus 362.45
+    Kiwano 389.32
+    Honeydew 1278.75
+    Lime 357.17
+    Avocado 753.36
+    Cactus_Pear 175.50
+    Passion_Fruit 502.38
+    Celery 326.03
+    Peach 685.93
+    Carrot 609.23
+    Rutabaga 564.00
+    Chard 108.24
+    Pear 393.21
+    Apple 782.19
+    Mango 463.26
+    Garlic 414.50
+    Cranberry 841.69
+    Radish 334.00
+    Pumpkin 586.52
+    Yam 152.90
+    Blackberry 230.70
+    Oregano 791.62
+    Cilantro 685.66
+    Bok_Choy 287.05
+    Raspberry 640.08
+    Beet 427.11
+    Apricot 579.42
+    Date 667.39
+    Orange 250.04
+    Rosemary 129.84
+    Green_Beans 215.11
+    Tomato 107.51
+    Spinach 330.56
+    Starfruit 653.48
+    Fig 561.84
+    Pomegranate 1048.54
+    Clementine 556.65
+    Zucchini 180.98
+    Banana 344.62
+    Nectarine 262.66
+    Goji_Berry 419.85
+    Acorn_Squash 1011.27
+    Onion 533.10
+    Coconut 830.33
+    Eggplant 303.46
+    Cauliflower 287.84
+    Mint 562.47
+    Guava 617.56
+    Papaya 802.88
+    Ginger 215.26
+    Broccoli 406.93
+    Watercress 629.50
+    Lettuce 133.49
+    Thyme 365.64
+    Persimmon 279.45
+    Pineapple 683.78
+    Grapefruit 511.74
+    Salsify 672.79
+    Okra 768.18
+    Sweet_Potato 859.41
+    Brussels_Sprouts 409.07
+    Sage 277.17
+    Bell_Pepper 687.96
+    Butternut_Squash 278.26
+    Collard_Greens 561.65
+    Jicama 322.05
+    Plum 384.68
+    Kiwi 710.42
+    Artichoke 1327.91
+    Parsnip 242.81
+    Squash_Blossom 676.91
+    Cherry 414.60
+    Tangier 51983.60
+    Bok_Choy 529.40
+    Spinach 688.80
+    Butternut_Squash 464.19
+    Sage 470.05
+    Raspberry 439.93
+    Mint 554.40
+    Basil 348.45
+    Cabbage 830.85
+    Papaya 612.57
+    Thyme 758.08
+    Potato 527.55
+    Jackfruit 176.53
+    Pear 759.51
+    Eggplant 808.31
+    Endive 393.15
+    Salsify 368.94
+    Blueberry 430.40
+    Brussels_Sprouts 1142.13
+    Lettuce 798.08
+    Starfruit 240.52
+    Garlic 340.80
+    Chard 488.33
+    Artichoke 493.02
+    Cherry 213.49
+    Jicama 467.83
+    Asparagus 383.25
+    Pineapple 492.05
+    Sweet_Potato 747.93
+    Clementine 203.77
+    Avocado 362.02
+    Kiwano 196.23
+    Blackberry 363.88
+    Squash_Blossom 411.27
+    Nectarine 636.78
+    Pomegranate 790.82
+    Plum 441.30
+    Guava 402.84
+    Mango 500.81
+    Ginger 636.61
+    Lime 365.36
+    Okra 604.07
+    Orange 388.20
+    Turnip 438.60
+    Honeydew 1283.28
+    Carrot 252.98
+    Cranberry 836.50
+    Persimmon 616.06
+    Beet 495.39
+    Pumpkin 560.98
+    Zucchini 433.53
+    Kohlrabi 391.73
+    Yam 606.26
+    Coconut 1528.00
+    Rosemary 822.73
+    Tomato 324.45
+    Cilantro 427.62
+    Lemon 244.05
+    Parsnip 378.06
+    Oregano 534.75
+    Watercress 749.60
+    Rutabaga 787.15
+    Broccoli 461.43
+    Watermelon 435.64
+    Goji_Berry 782.70
+    Celery 1006.08
+    Plantain 586.48
+    Peas 419.20
+    Grapefruit 1039.61
+    Cauliflower 800.79
+    Banana 604.26
+    Fig 592.05
+    Strawberry 319.37
+    Apple 289.45
+    Cantaloupe 843.97
+    Cactus_Pear 440.98
+    Peach 841.74
+    Currant 334.15
+    Rhubarb 879.13
+    Collard_Greens 855.91
+    Date 883.19
+    Parsley 705.34
+    Passion_Fruit 194.96
+    Cucumber 539.20
+    Acorn_Squash 418.39
+    Onion 633.04
+    Bell_Pepper 471.29
+    Dragon_Fruit 746.43
+    Dill 357.12
+    Kiwi 423.84
+    Green_Beans 278.32
+    Grapes 318.30
+    Apricot 589.90
+    Kale 864.00
+    Radish 43.12
+    Azilal 47585.85
+    Cactus_Pear 544.15
+    Passion_Fruit 153.43
+    Parsley 195.62
+    Coconut 745.50
+    Kiwi 545.05
+    Zucchini 460.44
+    Radish 305.58
+    Ginger 474.03
+    Brussels_Sprouts 244.73
+    Cherry 324.51
+    Dill 385.28
+    Pumpkin 455.57
+    Persimmon 304.42
+    Starfruit 746.49
+    Lemon 455.28
+    Salsify 338.61
+    Date 348.60
+    Mint 459.82
+    Squash_Blossom 613.94
+    Chard 239.00
+    Currant 342.39
+    Eggplant 388.48
+    Cranberry 948.97
+    Sweet_Potato 737.16
+    Cauliflower 588.64
+    Pomegranate 1317.90
+    Onion 836.34
+    Banana 427.91
+    Asparagus 179.75
+    Honeydew 736.56
+    Parsnip 566.13
+    Peach 760.27
+    Nectarine 1000.39
+    Papaya 384.43
+    Orange 766.15
+    Dragon_Fruit 523.56
+    Apple 364.81
+    Pineapple 436.05
+    Lettuce 492.67
+    Turnip 640.82
+    Apricot 273.73
+    Garlic 731.15
+    Rhubarb 537.77
+    Cucumber 409.54
+    Potato 566.54
+    Yam 668.86
+    Peas 618.03
+    Cantaloupe 955.21
+    Oregano 193.38
+    Carrot 413.90
+    Celery 441.06
+    Artichoke 844.37
+    Watermelon 349.33
+    Mango 405.49
+    Fig 210.60
+    Plantain 512.53
+    Beet 402.84
+    Kiwano 239.40
+    Clementine 416.10
+    Bell_Pepper 517.57
+    Kale 572.50
+    Rosemary 593.21
+    Bok_Choy 113.09
+    Blackberry 377.30
+    Thyme 252.64
+    Lime 742.36
+    Pear 366.20
+    Green_Beans 463.37
+    Strawberry 728.42
+    Watercress 613.69
+    Rutabaga 810.25
+    Grapefruit 656.22
+    Okra 450.68
+    Plum 705.70
+    Butternut_Squash 244.07
+    Cilantro 522.51
+    Raspberry 354.28
+    Jicama 668.23
+    Tomato 443.97
+    Kohlrabi 529.91
+    Goji_Berry 214.63
+    Acorn_Squash 887.25
+    Spinach 540.76
+    Collard_Greens 681.51
+    Endive 432.34
+    Guava 654.18
+    Blueberry 508.68
+    Jackfruit 610.48
+    Basil 485.19
+    Avocado 358.55
+    Sage 533.01
+    Cabbage 390.53
+    Broccoli 198.60
+    Grapes 394.71
+    Figuig 49177.53
+    Thyme 484.49
+    Plantain 315.35
+    Blueberry 703.82
+    Honeydew 1275.92
+    Tomato 603.19
+    Nectarine 483.52
+    Lime 451.40
+    Papaya 553.52
+    Kohlrabi 315.88
+    Goji_Berry 364.21
+    Butternut_Squash 339.51
+    Cauliflower 477.60
+    Oregano 315.71
+    Radish 485.07
+    Turnip 680.39
+    Cantaloupe 1264.01
+    Asparagus 454.94
+    Collard_Greens 213.93
+    Coconut 1168.25
+    Potato 637.09
+    Ginger 660.14
+    Parsley 378.75
+    Fig 506.52
+    Eggplant 453.96
+    Mango 486.18
+    Squash_Blossom 397.39
+    Brussels_Sprouts 212.89
+    Grapes 287.22
+    Persimmon 423.50
+    Cabbage 352.09
+    Guava 582.47
+    Starfruit 494.09
+    Chard 401.17
+    Lettuce 837.38
+    Rutabaga 545.92
+    Cactus_Pear 270.35
+    Yam 771.73
+    Avocado 394.11
+    Cilantro 732.99
+    Zucchini 756.67
+    Rosemary 571.01
+    Sweet_Potato 399.75
+    Cranberry 959.15
+    Spinach 229.32
+    Apricot 560.67
+    Celery 550.41
+    Cherry 405.13
+    Green_Beans 498.48
+    Acorn_Squash 825.90
+    Broccoli 374.43
+    Basil 647.51
+    Currant 301.78
+    Peas 615.38
+    Banana 352.94
+    Salsify 238.91
+    Dragon_Fruit 502.26
+    Kiwi 379.73
+    Carrot 423.06
+    Apple 638.30
+    Dill 429.26
+    Grapefruit 687.10
+    Bell_Pepper 250.42
+    Jackfruit 587.27
+    Peach 783.25
+    Strawberry 513.43
+    Kiwano 504.06
+    Rhubarb 430.29
+    Blackberry 681.97
+    Sage 308.50
+    Artichoke 696.31
+    Beet 1064.58
+    Mint 527.16
+    Parsnip 746.93
+    Cucumber 338.68
+    Pomegranate 1048.79
+    Lemon 321.26
+    Bok_Choy 688.10
+    Pear 611.09
+    Garlic 573.51
+    Endive 342.47
+    Watermelon 581.62
+    Pineapple 394.72
+    Kale 506.90
+    Pumpkin 521.92
+    Orange 240.58
+    Plum 343.35
+    Jicama 356.09
+    Onion 292.50
+    Raspberry 468.83
+    Watercress 511.11
+    Passion_Fruit 535.35
+    Okra 491.53
+    Date 314.31
+    Clementine 476.85
+    Khemisset 51800.14
+    Nectarine 502.96
+    Cranberry 869.80
+    Persimmon 174.50
+    Jackfruit 266.18
+    Watermelon 499.64
+    Cilantro 171.19
+    Goji_Berry 496.69
+    Acorn_Squash 420.42
+    Eggplant 536.28
+    Beet 459.41
+    Onion 441.72
+    Butternut_Squash 603.52
+    Cauliflower 372.05
+    Guava 544.67
+    Avocado 608.18
+    Strawberry 440.65
+    Watercress 732.61
+    Spinach 371.59
+    Sweet_Potato 508.66
+    Raspberry 474.45
+    Kiwi 811.27
+    Pumpkin 981.80
+    Green_Beans 773.75
+    Artichoke 1219.30
+    Apricot 502.22
+    Parsley 445.37
+    Honeydew 1120.86
+    Plum 505.22
+    Fig 359.65
+    Bok_Choy 365.98
+    Rosemary 418.70
+    Orange 625.74
+    Blackberry 268.90
+    Squash_Blossom 376.07
+    Broccoli 425.38
+    Potato 585.65
+    Zucchini 900.23
+    Coconut 1215.59
+    Cactus_Pear 168.73
+    Rhubarb 333.94
+    Okra 375.20
+    Pineapple 380.08
+    Cucumber 1244.55
+    Clementine 561.86
+    Garlic 504.65
+    Ginger 734.36
+    Papaya 330.48
+    Salsify 422.21
+    Cherry 374.38
+    Banana 421.29
+    Lime 216.03
+    Cabbage 673.88
+    Cantaloupe 1019.70
+    Starfruit 440.30
+    Oregano 605.53
+    Celery 489.65
+    Lettuce 423.47
+    Mint 751.08
+    Sage 658.89
+    Plantain 143.27
+    Mango 409.19
+    Blueberry 688.76
+    Date 593.84
+    Tomato 471.01
+    Peas 463.67
+    Dragon_Fruit 497.75
+    Turnip 547.69
+    Brussels_Sprouts 344.98
+    Passion_Fruit 222.68
+    Thyme 330.10
+    Kale 698.81
+    Yam 644.92
+    Grapefruit 497.72
+    Parsnip 643.81
+    Rutabaga 582.29
+    Peach 563.78
+    Chard 281.47
+    Endive 480.12
+    Kiwano 444.39
+    Apple 543.79
+    Carrot 657.15
+    Basil 645.30
+    Asparagus 563.37
+    Dill 419.34
+    Pear 553.13
+    Radish 565.49
+    Kohlrabi 504.07
+    Bell_Pepper 540.33
+    Collard_Greens 711.17
+    Lemon 452.38
+    Currant 804.12
+    Jicama 430.82
+    Grapes 861.55
+    Pomegranate 1470.77
+    Aourir 49968.21
+    Apricot 520.02
+    Sweet_Potato 661.98
+    Currant 423.19
+    Guava 567.19
+    Orange 375.67
+    Tomato 496.08
+    Parsley 550.38
+    Kiwi 467.27
+    Mint 413.15
+    Acorn_Squash 654.02
+    Rhubarb 624.93
+    Watercress 459.56
+    Cilantro 306.63
+    Passion_Fruit 448.48
+    Brussels_Sprouts 415.36
+    Clementine 772.06
+    Peach 216.86
+    Artichoke 1228.55
+    Bok_Choy 461.19
+    Banana 197.87
+    Squash_Blossom 479.66
+    Grapes 731.29
+    Cranberry 1313.99
+    Spinach 433.03
+    Garlic 428.79
+    Jackfruit 537.18
+    Coconut 646.85
+    Starfruit 621.37
+    Persimmon 227.67
+    Nectarine 542.22
+    Cantaloupe 1017.06
+    Oregano 549.20
+    Butternut_Squash 472.25
+    Cucumber 277.41
+    Sage 467.58
+    Plum 526.28
+    Plantain 220.77
+    Watermelon 312.69
+    Avocado 281.94
+    Radish 428.43
+    Cabbage 748.70
+    Peas 465.44
+    Kohlrabi 663.05
+    Kiwano 432.91
+    Dill 572.99
+    Bell_Pepper 551.68
+    Cauliflower 506.80
+    Celery 455.35
+    Parsnip 560.43
+    Strawberry 303.69
+    Lemon 1083.09
+    Beet 615.10
+    Ginger 280.33
+    Eggplant 592.40
+    Apple 601.53
+    Grapefruit 757.50
+    Cherry 716.87
+    Basil 255.81
+    Broccoli 468.33
+    Cactus_Pear 897.84
+    Jicama 303.15
+    Honeydew 954.23
+    Salsify 413.93
+    Yam 479.99
+    Lime 208.13
+    Carrot 523.59
+    Onion 410.77
+    Blueberry 822.79
+    Okra 302.98
+    Thyme 352.21
+    Turnip 529.77
+    Goji_Berry 399.55
+    Potato 546.62
+    Green_Beans 790.10
+    Lettuce 703.16
+    Mango 438.86
+    Rosemary 485.72
+    Collard_Greens 583.97
+    Pumpkin 103.53
+    Raspberry 544.18
+    Asparagus 771.50
+    Pear 508.36
+    Fig 591.32
+    Chard 389.30
+    Pomegranate 948.24
+    Date 484.50
+    Kale 450.87
+    Pineapple 390.51
+    Dragon_Fruit 458.60
+    Blackberry 667.89
+    Rutabaga 401.09
+    Zucchini 958.62
+    Papaya 488.65
+    Endive 255.59
+    Bouarfa 51091.00
+    Banana 256.28
+    Bell_Pepper 568.48
+    Butternut_Squash 564.98
+    Pineapple 529.61
+    Sage 650.77
+    Bok_Choy 501.88
+    Plum 616.12
+    Avocado 242.29
+    Watermelon 701.30
+    Garlic 516.46
+    Oregano 517.84
+    Cantaloupe 809.26
+    Peas 295.98
+    Fig 666.37
+    Brussels_Sprouts 397.26
+    Radish 432.55
+    Yam 411.73
+    Coconut 1044.26
+    Papaya 556.03
+    Raspberry 599.45
+    Grapefruit 291.27
+    Acorn_Squash 437.84
+    Persimmon 140.78
+    Celery 337.73
+    Artichoke 1094.72
+    Rhubarb 936.67
+    Collard_Greens 386.71
+    Strawberry 477.47
+    Blueberry 508.55
+    Cucumber 851.42
+    Honeydew 991.94
+    Kiwano 768.00
+    Cilantro 101.61
+    Rosemary 767.63
+    Lettuce 268.90
+    Apricot 306.35
+    Date 534.08
+    Pear 254.90
+    Peach 654.21
+    Parsnip 223.97
+    Endive 556.01
+    Basil 382.65
+    Spinach 938.04
+    Kohlrabi 442.63
+    Chard 526.32
+    Pomegranate 1164.31
+    Asparagus 696.62
+    Dill 184.34
+    Mint 565.18
+    Kiwi 479.03
+    Zucchini 553.60
+    Okra 610.19
+    Turnip 262.10
+    Broccoli 511.65
+    Tomato 506.76
+    Guava 405.01
+    Cherry 946.33
+    Parsley 532.91
+    Carrot 516.95
+    Lime 830.68
+    Potato 362.94
+    Plantain 346.24
+    Cauliflower 662.72
+    Green_Beans 519.06
+    Lemon 199.00
+    Cactus_Pear 350.25
+    Apple 792.41
+    Rutabaga 456.23
+    Orange 426.11
+    Thyme 368.08
+    Blackberry 649.22
+    Eggplant 720.62
+    Squash_Blossom 611.01
+    Watercress 604.93
+    Sweet_Potato 537.18
+    Beet 523.48
+    Cabbage 502.62
+    Ginger 610.13
+    Grapes 644.40
+    Jackfruit 733.29
+    Cranberry 1211.24
+    Onion 456.34
+    Clementine 737.05
+    Currant 456.78
+    Dragon_Fruit 156.52
+    Kale 705.80
+    Passion_Fruit 450.61
+    Salsify 561.21
+    Pumpkin 496.13
+    Starfruit 618.62
+    Jicama 268.78
+    Goji_Berry 475.41
+    Nectarine 754.67
+    Mango 296.96
+    Oujda 51978.54
+    Asparagus 134.70
+    Cactus_Pear 114.81
+    Goji_Berry 236.33
+    Parsnip 757.93
+    Garlic 276.46
+    Watercress 494.53
+    Mango 665.28
+    Lime 603.53
+    Sage 494.67
+    Onion 720.41
+    Pomegranate 958.72
+    Cilantro 439.58
+    Pineapple 772.64
+    Squash_Blossom 463.41
+    Rutabaga 410.25
+    Basil 134.90
+    Turnip 645.77
+    Orange 392.16
+    Zucchini 321.97
+    Passion_Fruit 456.59
+    Oregano 730.33
+    Bell_Pepper 758.58
+    Starfruit 307.56
+    Peas 437.48
+    Coconut 985.39
+    Potato 682.63
+    Honeydew 1299.50
+    Raspberry 560.85
+    Artichoke 1457.83
+    Grapes 831.75
+    Kohlrabi 458.15
+    Green_Beans 550.68
+    Jackfruit 362.08
+    Radish 564.58
+    Grapefruit 358.34
+    Apple 619.27
+    Sweet_Potato 707.70
+    Plantain 606.96
+    Cherry 360.85
+    Rosemary 475.09
+    Guava 372.71
+    Endive 783.26
+    Acorn_Squash 439.97
+    Date 733.67
+    Blackberry 725.35
+    Lettuce 470.33
+    Bok_Choy 376.59
+    Eggplant 469.87
+    Cantaloupe 1036.20
+    Currant 697.30
+    Blueberry 433.74
+    Plum 479.67
+    Clementine 531.66
+    Butternut_Squash 271.28
+    Kiwi 812.55
+    Beet 479.51
+    Watermelon 304.92
+    Papaya 431.17
+    Thyme 382.54
+    Carrot 236.04
+    Brussels_Sprouts 1018.44
+    Kale 432.63
+    Lemon 710.57
+    Cranberry 615.99
+    Yam 615.28
+    Cabbage 808.34
+    Spinach 600.12
+    Cauliflower 568.50
+    Ginger 691.11
+    Peach 751.93
+    Banana 234.46
+    Celery 464.39
+    Tomato 356.45
+    Nectarine 508.70
+    Parsley 488.44
+    Avocado 515.17
+    Cucumber 354.13
+    Collard_Greens 549.10
+    Salsify 448.07
+    Okra 1011.23
+    Persimmon 582.56
+    Strawberry 447.32
+    Apricot 368.56
+    Pear 374.81
+    Chard 265.60
+    Fig 397.97
+    Kiwano 487.55
+    Pumpkin 405.46
+    Dill 480.01
+    Dragon_Fruit 791.89
+    Mint 708.04
+    Jicama 527.37
+    Broccoli 593.25
+    Rhubarb 726.53
+    Demnate 51808.74
+    Pineapple 754.91
+    Kohlrabi 785.71
+    Guava 485.86
+    Kiwano 491.82
+    Plantain 370.98
+    Lime 413.52
+    Cilantro 601.30
+    Watermelon 540.63
+    Carrot 583.24
+    Butternut_Squash 665.67
+    Beet 477.69
+    Ginger 582.75
+    Nectarine 505.50
+    Garlic 528.14
+    Lemon 225.34
+    Rosemary 359.24
+    Goji_Berry 241.42
+    Basil 838.32
+    Thyme 606.03
+    Parsnip 669.51
+    Rutabaga 698.96
+    Endive 393.80
+    Cactus_Pear 276.29
+    Fig 510.80
+    Starfruit 773.18
+    Cantaloupe 1090.31
+    Broccoli 514.83
+    Cauliflower 427.77
+    Papaya 186.23
+    Rhubarb 189.21
+    Chard 584.60
+    Apple 261.22
+    Eggplant 356.76
+    Bell_Pepper 711.87
+    Lettuce 839.45
+    Strawberry 467.35
+    Pumpkin 271.58
+    Acorn_Squash 541.39
+    Artichoke 1259.74
+    Spinach 470.06
+    Blueberry 394.30
+    Cabbage 456.55
+    Zucchini 361.57
+    Grapes 537.16
+    Persimmon 655.99
+    Mango 545.74
+    Kiwi 605.72
+    Sage 639.39
+    Yam 757.25
+    Peach 256.92
+    Watercress 663.64
+    Mint 400.90
+    Plum 463.59
+    Cucumber 682.66
+    Orange 832.50
+    Honeydew 751.07
+    Green_Beans 608.04
+    Asparagus 350.66
+    Turnip 446.26
+    Okra 637.25
+    Collard_Greens 366.71
+    Celery 597.47
+    Radish 708.78
+    Cherry 792.36
+    Peas 432.27
+    Jicama 619.74
+    Clementine 266.11
+    Onion 419.85
+    Parsley 553.79
+    Apricot 317.89
+    Oregano 316.48
+    Currant 778.98
+    Brussels_Sprouts 525.66
+    Cranberry 599.97
+    Grapefruit 558.31
+    Dragon_Fruit 437.79
+    Pear 624.86
+    Passion_Fruit 347.49
+    Coconut 1367.12
+    Dill 605.30
+    Avocado 532.21
+    Bok_Choy 699.19
+    Jackfruit 530.39
+    Date 165.03
+    Squash_Blossom 654.83
+    Raspberry 505.43
+    Tomato 631.80
+    Potato 627.62
+    Sweet_Potato 485.33
+    Salsify 510.62
+    Blackberry 433.76
+    Pomegranate 1355.20
+    Kale 486.53
+    Banana 353.73
+    Tafraout 49948.03
+    Turnip 764.04
+    Rosemary 281.82
+    Squash_Blossom 464.60
+    Cherry 430.42
+    Kiwano 411.58
+    Jackfruit 345.58
+    Pear 837.83
+    Peas 540.10
+    Celery 524.43
+    Beet 577.04
+    Dill 441.07
+    Artichoke 1002.37
+    Salsify 653.03
+    Pomegranate 1072.71
+    Green_Beans 443.05
+    Radish 525.10
+    Banana 290.14
+    Grapefruit 672.54
+    Cabbage 481.93
+    Cucumber 524.04
+    Mango 333.32
+    Cactus_Pear 381.23
+    Ginger 936.19
+    Cranberry 888.02
+    Sage 498.84
+    Asparagus 550.38
+    Parsnip 481.16
+    Coconut 1172.37
+    Blackberry 256.65
+    Acorn_Squash 331.22
+    Lime 254.76
+    Yam 384.62
+    Eggplant 518.95
+    Rutabaga 609.59
+    Mint 589.27
+    Raspberry 416.17
+    Cilantro 347.35
+    Currant 716.80
+    Strawberry 766.67
+    Oregano 270.94
+    Zucchini 280.62
+    Blueberry 286.73
+    Plantain 475.48
+    Pumpkin 514.22
+    Rhubarb 555.97
+    Watercress 808.35
+    Cantaloupe 1525.85
+    Chard 1021.93
+    Plum 482.53
+    Okra 495.32
+    Spinach 362.20
+    Garlic 344.14
+    Nectarine 559.78
+    Grapes 694.94
+    Watermelon 196.92
+    Persimmon 669.66
+    Jicama 338.11
+    Butternut_Squash 687.44
+    Clementine 515.59
+    Kiwi 521.60
+    Papaya 444.33
+    Parsley 631.33
+    Orange 462.57
+    Lettuce 254.27
+    Apricot 662.06
+    Cauliflower 419.13
+    Honeydew 781.41
+    Thyme 553.47
+    Endive 529.19
+    Bok_Choy 587.14
+    Lemon 571.64
+    Guava 267.20
+    Broccoli 428.97
+    Starfruit 543.36
+    Carrot 815.45
+    Peach 514.06
+    Potato 471.60
+    Pineapple 586.59
+    Kohlrabi 436.12
+    Fig 252.38
+    Kale 203.84
+    Basil 253.97
+    Brussels_Sprouts 724.20
+    Apple 550.91
+    Avocado 667.68
+    Goji_Berry 472.19
+    Passion_Fruit 584.41
+    Tomato 367.36
+    Dragon_Fruit 514.52
+    Bell_Pepper 301.17
+    Date 169.65
+    Sweet_Potato 533.78
+    Onion 502.86
+    Collard_Greens 563.92
+    Guelta_Zemmur 49408.24
+    Kale 580.35
+    Blueberry 473.62
+    Watercress 471.42
+    Spinach 1066.94
+    Cranberry 537.14
+    Tomato 936.01
+    Raspberry 693.24
+    Kiwi 308.92
+    Pineapple 505.71
+    Carrot 739.59
+    Endive 594.93
+    Jicama 385.01
+    Salsify 641.82
+    Cactus_Pear 347.82
+    Currant 533.09
+    Basil 520.15
+    Mint 258.26
+    Thyme 421.65
+    Lettuce 595.29
+    Celery 380.33
+    Banana 446.85
+    Lime 728.11
+    Starfruit 264.27
+    Passion_Fruit 244.66
+    Potato 298.84
+    Asparagus 845.41
+    Turnip 431.56
+    Orange 194.43
+    Onion 160.32
+    Rhubarb 376.38
+    Bok_Choy 476.68
+    Grapes 444.41
+    Grapefruit 614.15
+    Goji_Berry 679.95
+    Mango 568.88
+    Lemon 656.46
+    Cauliflower 911.74
+    Acorn_Squash 456.73
+    Avocado 230.76
+    Papaya 496.74
+    Cucumber 589.94
+    Kiwano 446.75
+    Coconut 820.15
+    Bell_Pepper 352.18
+    Brussels_Sprouts 698.04
+    Parsley 252.31
+    Pomegranate 1179.57
+    Peas 496.89
+    Plantain 701.17
+    Apricot 455.88
+    Butternut_Squash 903.42
+    Dragon_Fruit 407.84
+    Squash_Blossom 530.99
+    Nectarine 567.06
+    Garlic 441.27
+    Rosemary 500.28
+    Guava 448.90
+    Rutabaga 383.42
+    Apple 425.25
+    Fig 886.31
+    Kohlrabi 502.62
+    Peach 506.82
+    Cabbage 609.91
+    Okra 522.60
+    Date 307.48
+    Broccoli 439.21
+    Cilantro 475.54
+    Green_Beans 273.16
+    Persimmon 701.95
+    Chard 177.47
+    Oregano 616.37
+    Beet 644.85
+    Honeydew 752.26
+    Parsnip 293.62
+    Eggplant 293.26
+    Collard_Greens 177.11
+    Dill 504.97
+    Radish 680.97
+    Clementine 516.92
+    Blackberry 533.26
+    Strawberry 971.61
+    Pear 190.74
+    Sage 459.88
+    Plum 328.97
+    Ginger 548.98
+    Watermelon 443.93
+    Artichoke 1129.99
+    Cherry 270.25
+    Pumpkin 526.34
+    Yam 442.87
+    Jackfruit 635.82
+    Sweet_Potato 513.84
+    Zucchini 402.85
+    Cantaloupe 1005.58
+    Temara 51995.59
+    Mango 667.75
+    Strawberry 649.04
+    Grapefruit 389.47
+    Pomegranate 1253.81
+    Artichoke 1044.41
+    Persimmon 288.47
+    Cucumber 608.71
+    Bell_Pepper 682.84
+    Guava 391.85
+    Honeydew 1578.24
+    Rhubarb 790.36
+    Sage 524.59
+    Dill 656.15
+    Beet 664.32
+    Radish 381.72
+    Nectarine 597.56
+    Thyme 701.83
+    Collard_Greens 452.45
+    Currant 977.94
+    Fig 542.72
+    Cherry 339.40
+    Garlic 358.42
+    Avocado 694.68
+    Apple 359.82
+    Chard 643.15
+    Peach 539.44
+    Parsnip 482.23
+    Raspberry 387.13
+    Pineapple 626.08
+    Bok_Choy 557.32
+    Parsley 648.18
+    Onion 520.94
+    Watermelon 195.49
+    Tomato 592.38
+    Watercress 436.61
+    Eggplant 470.17
+    Orange 785.22
+    Papaya 633.28
+    Peas 258.53
+    Green_Beans 562.01
+    Cilantro 794.67
+    Asparagus 639.69
+    Turnip 539.23
+    Okra 493.53
+    Cabbage 681.38
+    Grapes 510.84
+    Passion_Fruit 676.54
+    Mint 211.85
+    Cranberry 788.14
+    Jackfruit 516.24
+    Goji_Berry 449.24
+    Banana 546.46
+    Kohlrabi 452.43
+    Spinach 416.30
+    Acorn_Squash 473.87
+    Clementine 89.55
+    Lime 585.19
+    Ginger 765.11
+    Apricot 500.62
+    Butternut_Squash 391.50
+    Dragon_Fruit 688.20
+    Jicama 441.18
+    Yam 709.59
+    Pear 490.69
+    Blueberry 382.01
+    Kiwano 393.23
+    Basil 321.82
+    Coconut 1087.46
+    Kale 620.09
+    Brussels_Sprouts 701.53
+    Zucchini 534.13
+    Lettuce 394.41
+    Cauliflower 308.37
+    Cantaloupe 1169.69
+    Salsify 477.64
+    Rutabaga 373.35
+    Starfruit 477.83
+    Plum 355.69
+    Cactus_Pear 623.94
+    Rosemary 509.54
+    Squash_Blossom 292.23
+    Oregano 428.17
+    Celery 397.27
+    Potato 204.73
+    Plantain 540.50
+    Broccoli 266.14
+    Endive 360.42
+    Carrot 759.53
+    Lemon 386.58
+    Pumpkin 580.47
+    Blackberry 619.14
+    Kiwi 549.59
+    Sweet_Potato 388.95
+    Date 704.39
+    Drarga 50299.16
+    Cherry 691.55
+    Grapefruit 726.20
+    Raspberry 581.37
+    Persimmon 401.37
+    Clementine 382.97
+    Lemon 430.35
+    Plantain 524.05
+    Sweet_Potato 624.31
+    Guava 626.83
+    Strawberry 286.48
+    Artichoke 1165.20
+    Cabbage 450.37
+    Endive 734.49
+    Mango 501.07
+    Grapes 141.61
+    Mint 747.79
+    Lime 851.94
+    Honeydew 1155.89
+    Watermelon 366.38
+    Spinach 690.76
+    Cantaloupe 1104.71
+    Okra 636.52
+    Bell_Pepper 603.33
+    Green_Beans 440.52
+    Kiwi 355.21
+    Cranberry 1369.61
+    Pomegranate 716.52
+    Blackberry 320.59
+    Potato 423.45
+    Garlic 455.97
+    Peas 424.77
+    Cactus_Pear 441.23
+    Peach 328.58
+    Parsnip 524.51
+    Date 588.32
+    Thyme 500.75
+    Acorn_Squash 369.47
+    Cucumber 538.83
+    Salsify 468.70
+    Orange 571.28
+    Dragon_Fruit 552.65
+    Starfruit 695.76
+    Watercress 422.88
+    Parsley 251.11
+    Banana 669.57
+    Plum 626.07
+    Dill 807.34
+    Kale 840.28
+    Squash_Blossom 454.13
+    Nectarine 301.65
+    Cilantro 389.48
+    Carrot 527.29
+    Jackfruit 220.20
+    Basil 696.12
+    Ginger 633.56
+    Radish 282.79
+    Avocado 432.45
+    Papaya 441.56
+    Brussels_Sprouts 565.36
+    Collard_Greens 399.61
+    Yam 259.98
+    Turnip 570.16
+    Currant 767.68
+    Lettuce 628.63
+    Pineapple 558.50
+    Broccoli 696.36
+    Pumpkin 535.64
+    Sage 556.40
+    Apple 748.21
+    Passion_Fruit 385.93
+    Jicama 500.37
+    Rosemary 449.50
+    Rutabaga 271.51
+    Butternut_Squash 410.99
+    Zucchini 399.82
+    Goji_Berry 714.36
+    Oregano 458.31
+    Blueberry 445.73
+    Kohlrabi 1074.90
+    Celery 403.48
+    Tomato 458.61
+    Rhubarb 482.06
+    Pear 433.01
+    Chard 284.77
+    Coconut 436.42
+    Beet 430.54
+    Fig 399.03
+    Eggplant 623.41
+    Onion 323.36
+    Apricot 497.36
+    Kiwano 278.36
+    Cauliflower 284.09
+    Asparagus 601.47
+    Bok_Choy 456.50
+    Inezgane 49213.70
+    Grapefruit 370.45
+    Currant 429.11
+    Oregano 210.52
+    Peas 769.92
+    Yam 719.17
+    Parsnip 516.65
+    Blackberry 340.11
+    Blueberry 795.13
+    Kale 659.15
+    Pear 331.35
+    Acorn_Squash 448.43
+    Apple 478.98
+    Pineapple 279.93
+    Lemon 292.89
+    Passion_Fruit 468.03
+    Plantain 771.60
+    Sage 788.12
+    Bok_Choy 336.75
+    Dill 418.98
+    Rosemary 334.95
+    Chard 505.07
+    Fig 443.90
+    Coconut 1220.39
+    Watermelon 330.30
+    Nectarine 724.34
+    Turnip 706.04
+    Cucumber 421.84
+    Mango 512.15
+    Lime 174.35
+    Strawberry 291.70
+    Raspberry 826.18
+    Jicama 355.23
+    Bell_Pepper 132.05
+    Kiwi 404.34
+    Green_Beans 590.66
+    Potato 226.64
+    Salsify 502.08
+    Kohlrabi 315.39
+    Sweet_Potato 721.65
+    Onion 665.70
+    Cabbage 220.23
+    Orange 606.19
+    Peach 447.15
+    Dragon_Fruit 206.66
+    Beet 160.91
+    Pumpkin 807.21
+    Goji_Berry 653.29
+    Pomegranate 958.15
+    Honeydew 1101.82
+    Persimmon 244.29
+    Rhubarb 460.71
+    Broccoli 505.86
+    Papaya 516.35
+    Zucchini 543.40
+    Artichoke 1126.10
+    Cactus_Pear 529.07
+    Watercress 313.89
+    Lettuce 786.99
+    Cantaloupe 903.57
+    Grapes 265.40
+    Spinach 288.64
+    Collard_Greens 438.56
+    Guava 512.22
+    Jackfruit 244.21
+    Mint 101.10
+    Ginger 515.34
+    Rutabaga 418.46
+    Carrot 624.28
+    Avocado 453.32
+    Radish 792.82
+    Plum 535.91
+    Thyme 840.35
+    Kiwano 497.22
+    Cherry 358.86
+    Eggplant 422.74
+    Okra 393.03
+    Cranberry 767.32
+    Celery 346.01
+    Banana 647.22
+    Endive 973.35
+    Butternut_Squash 605.41
+    Asparagus 607.41
+    Brussels_Sprouts 602.56
+    Garlic 499.93
+    Parsley 519.02
+    Date 506.91
+    Tomato 262.05
+    Clementine 564.95
+    Starfruit 661.83
+    Squash_Blossom 831.67
+    Cilantro 513.70
+    Basil 657.68
+    Apricot 473.66
+    Cauliflower 548.50
+    El_Jadida 51213.30
+    Cabbage 499.90
+    Tomato 574.29
+    Brussels_Sprouts 393.75
+    Blackberry 588.45
+    Cilantro 545.24
+    Date 544.58
+    Strawberry 850.73
+    Asparagus 541.22
+    Chard 541.55
+    Collard_Greens 430.29
+    Kiwi 703.76
+    Squash_Blossom 596.81
+    Currant 326.48
+    Rhubarb 288.09
+    Honeydew 1016.76
+    Parsley 357.84
+    Passion_Fruit 1036.09
+    Apple 330.25
+    Mint 500.73
+    Grapes 400.78
+    Turnip 355.13
+    Rosemary 786.23
+    Peas 495.80
+    Lettuce 711.69
+    Grapefruit 589.17
+    Papaya 420.20
+    Sage 929.68
+    Thyme 646.09
+    Yam 725.24
+    Rutabaga 646.55
+    Green_Beans 315.37
+    Peach 538.59
+    Lemon 443.32
+    Mango 656.68
+    Lime 506.69
+    Fig 445.29
+    Plum 368.20
+    Pumpkin 317.04
+    Cantaloupe 688.05
+    Jicama 297.49
+    Cactus_Pear 456.41
+    Pomegranate 925.32
+    Parsnip 388.27
+    Bok_Choy 652.24
+    Carrot 505.27
+    Nectarine 354.99
+    Butternut_Squash 504.41
+    Starfruit 512.96
+    Jackfruit 371.57
+    Clementine 520.17
+    Onion 454.72
+    Raspberry 422.73
+    Pear 544.93
+    Watercress 478.18
+    Oregano 897.14
+    Zucchini 581.31
+    Kale 438.16
+    Basil 586.92
+    Avocado 660.15
+    Dill 340.04
+    Persimmon 231.25
+    Acorn_Squash 515.31
+    Goji_Berry 807.31
+    Eggplant 298.83
+    Garlic 389.80
+    Cucumber 457.27
+    Okra 404.76
+    Broccoli 800.45
+    Pineapple 496.93
+    Endive 796.57
+    Watermelon 783.12
+    Coconut 1162.95
+    Kohlrabi 296.76
+    Guava 494.95
+    Cauliflower 483.12
+    Spinach 827.06
+    Apricot 282.92
+    Bell_Pepper 210.64
+    Celery 872.18
+    Potato 266.34
+    Plantain 430.87
+    Kiwano 550.27
+    Salsify 360.50
+    Banana 436.89
+    Radish 248.12
+    Artichoke 1179.16
+    Blueberry 835.72
+    Cranberry 1163.39
+    Dragon_Fruit 337.78
+    Sweet_Potato 673.73
+    Beet 304.21
+    Orange 111.75
+    Cherry 514.45
+    Ginger 641.96
+    Nador 54979.94
+    Plum 445.44
+    Pomegranate 1121.77
+    Parsley 250.81
+    Parsnip 616.41
+    Turnip 641.20
+    Brussels_Sprouts 578.45
+    Nectarine 367.07
+    Yam 310.18
+    Honeydew 753.92
+    Orange 535.73
+    Coconut 948.13
+    Currant 443.97
+    Cauliflower 466.83
+    Cantaloupe 1123.57
+    Persimmon 669.31
+    Plantain 860.51
+    Asparagus 245.61
+    Beet 819.11
+    Onion 431.55
+    Clementine 484.26
+    Zucchini 447.15
+    Lime 541.88
+    Peas 334.75
+    Jicama 839.91
+    Cactus_Pear 410.50
+    Apricot 507.79
+    Kiwi 591.90
+    Green_Beans 379.16
+    Strawberry 486.22
+    Jackfruit 697.22
+    Salsify 438.79
+    Raspberry 504.60
+    Potato 527.77
+    Banana 462.42
+    Garlic 438.71
+    Eggplant 477.27
+    Chard 668.19
+    Celery 924.85
+    Squash_Blossom 925.45
+    Avocado 648.73
+    Cabbage 552.96
+    Tomato 460.81
+    Rosemary 931.86
+    Cilantro 624.10
+    Mint 606.86
+    Oregano 246.30
+    Fig 376.72
+    Starfruit 386.48
+    Basil 857.66
+    Papaya 755.29
+    Kohlrabi 286.98
+    Bell_Pepper 459.63
+    Radish 381.54
+    Grapefruit 653.48
+    Spinach 535.90
+    Dragon_Fruit 859.67
+    Cucumber 641.08
+    Pineapple 739.28
+    Ginger 515.28
+    Thyme 399.99
+    Acorn_Squash 541.66
+    Artichoke 1269.81
+    Collard_Greens 438.55
+    Pear 635.35
+    Sage 348.28
+    Carrot 597.76
+    Watercress 414.74
+    Okra 326.07
+    Passion_Fruit 783.16
+    Grapes 710.66
+    Bok_Choy 370.42
+    Lettuce 489.49
+    Kiwano 691.19
+    Rhubarb 662.19
+    Cranberry 1053.53
+    Butternut_Squash 435.03
+    Broccoli 598.87
+    Lemon 354.64
+    Rutabaga 746.65
+    Apple 668.63
+    Peach 704.72
+    Blueberry 509.22
+    Endive 440.16
+    Kale 610.84
+    Watermelon 893.51
+    Sweet_Potato 545.41
+    Guava 513.68
+    Goji_Berry 672.17
+    Date 525.24
+    Dill 471.11
+    Pumpkin 652.74
+    Mango 602.80
+    Cherry 516.99
+    Blackberry 545.71
+    Mohammedia 47114.49
+    Pomegranate 804.87
+    Cranberry 730.39
+    Okra 350.66
+    Rutabaga 344.81
+    Watercress 657.04
+    Blueberry 567.53
+    Cherry 380.80
+    Cilantro 422.52
+    Potato 433.80
+    Lime 418.79
+    Ginger 270.74
+    Goji_Berry 328.61
+    Fig 548.79
+    Persimmon 668.41
+    Strawberry 310.20
+    Basil 265.71
+    Grapefruit 256.61
+    Spinach 390.79
+    Mint 767.60
+    Papaya 502.61
+    Yam 637.50
+    Zucchini 568.15
+    Mango 526.21
+    Rosemary 362.96
+    Beet 329.71
+    Tomato 597.34
+    Chard 579.72
+    Asparagus 583.95
+    Cabbage 345.40
+    Honeydew 1093.73
+    Jackfruit 752.87
+    Dill 495.28
+    Sweet_Potato 690.94
+    Artichoke 631.45
+    Nectarine 322.28
+    Eggplant 567.12
+    Sage 416.52
+    Date 450.01
+    Lemon 292.02
+    Apricot 630.96
+    Kale 482.78
+    Turnip 771.42
+    Lettuce 427.32
+    Peach 457.26
+    Cucumber 539.29
+    Oregano 644.09
+    Acorn_Squash 499.97
+    Pear 360.30
+    Kohlrabi 251.78
+    Kiwi 609.91
+    Starfruit 625.86
+    Apple 500.78
+    Guava 263.50
+    Clementine 489.00
+    Plum 380.49
+    Cauliflower 446.37
+    Thyme 513.41
+    Jicama 975.82
+    Carrot 377.20
+    Cactus_Pear 776.60
+    Kiwano 290.43
+    Plantain 975.09
+    Avocado 384.98
+    Rhubarb 636.33
+    Onion 468.52
+    Celery 223.63
+    Banana 434.22
+    Butternut_Squash 551.33
+    Passion_Fruit 531.52
+    Brussels_Sprouts 599.75
+    Coconut 701.57
+    Broccoli 373.05
+    Green_Beans 470.57
+    Parsley 440.35
+    Garlic 416.98
+    Endive 212.68
+    Pumpkin 303.37
+    Collard_Greens 586.11
+    Blackberry 553.54
+    Watermelon 421.52
+    Pineapple 400.47
+    Currant 468.45
+    Bok_Choy 543.04
+    Peas 353.42
+    Parsnip 396.68
+    Dragon_Fruit 825.95
+    Orange 336.27
+    Bell_Pepper 386.32
+    Raspberry 541.12
+    Squash_Blossom 539.35
+    Radish 402.88
+    Grapes 214.38
+    Salsify 367.83
+    Cantaloupe 1074.24
+    Arfoud 54125.68
+    Celery 596.29
+    Oregano 413.49
+    Rhubarb 427.93
+    Passion_Fruit 545.00
+    Papaya 835.40
+    Radish 699.52
+    Pineapple 526.76
+    Onion 693.97
+    Acorn_Squash 653.51
+    Chard 528.78
+    Basil 441.82
+    Asparagus 556.42
+    Cherry 761.33
+    Grapefruit 299.57
+    Plantain 401.09
+    Cantaloupe 1477.25
+    Watercress 496.42
+    Goji_Berry 347.10
+    Salsify 572.86
+    Kiwi 554.77
+    Jackfruit 681.77
+    Avocado 559.11
+    Dragon_Fruit 231.78
+    Rosemary 389.84
+    Cauliflower 862.79
+    Orange 413.91
+    Yam 548.74
+    Coconut 507.25
+    Cactus_Pear 326.08
+    Tomato 436.36
+    Rutabaga 508.00
+    Date 872.00
+    Cranberry 687.42
+    Zucchini 189.11
+    Beet 795.36
+    Raspberry 862.19
+    Cucumber 764.67
+    Butternut_Squash 766.45
+    Parsnip 618.20
+    Bok_Choy 594.54
+    Green_Beans 366.62
+    Spinach 702.66
+    Brussels_Sprouts 714.30
+    Sweet_Potato 705.08
+    Pear 703.35
+    Parsley 477.58
+    Peach 459.42
+    Squash_Blossom 197.85
+    Grapes 661.19
+    Persimmon 647.13
+    Banana 572.36
+    Pumpkin 332.64
+    Blackberry 664.18
+    Nectarine 832.67
+    Watermelon 774.24
+    Bell_Pepper 509.28
+    Artichoke 1074.25
+    Peas 451.15
+    Turnip 376.03
+    Clementine 515.41
+    Plum 383.73
+    Garlic 673.64
+    Eggplant 937.93
+    Lime 297.55
+    Currant 723.96
+    Sage 669.29
+    Cabbage 620.56
+    Broccoli 491.65
+    Honeydew 1434.49
+    Apple 379.52
+    Cilantro 238.94
+    Lemon 986.53
+    Kohlrabi 230.67
+    Mint 276.49
+    Dill 511.76
+    Ginger 436.22
+    Endive 559.75
+    Kiwano 362.84
+    Starfruit 740.80
+    Potato 504.57
+    Blueberry 618.06
+    Apricot 123.89
+    Jicama 414.45
+    Mango 420.42
+    Collard_Greens 935.73
+    Strawberry 619.92
+    Guava 342.44
+    Fig 532.00
+    Lettuce 659.98
+    Kale 588.56
+    Thyme 131.03
+    Pomegranate 1019.73
+    Okra 724.48
+    Carrot 351.86
+    Guerguerat 47203.61
+    Coconut 1215.96
+    Beet 382.59
+    Tomato 680.82
+    Apple 622.07
+    Salsify 588.40
+    Asparagus 639.73
+    Ginger 474.76
+    Blueberry 256.90
+    Bell_Pepper 439.30
+    Avocado 341.33
+    Persimmon 298.81
+    Watermelon 695.91
+    Bok_Choy 177.79
+    Orange 369.11
+    Garlic 254.62
+    Pomegranate 1067.89
+    Cranberry 791.92
+    Kohlrabi 318.72
+    Passion_Fruit 121.51
+    Spinach 298.74
+    Pear 561.23
+    Yam 505.24
+    Kiwi 530.70
+    Dill 353.95
+    Jicama 439.41
+    Banana 373.40
+    Plantain 367.14
+    Butternut_Squash 326.29
+    Mango 431.71
+    Sweet_Potato 811.28
+    Cucumber 823.72
+    Zucchini 390.03
+    Carrot 483.28
+    Grapefruit 482.74
+    Grapes 602.75
+    Oregano 210.78
+    Blackberry 699.55
+    Watercress 705.33
+    Kiwano 493.22
+    Date 713.90
+    Cantaloupe 882.82
+    Apricot 543.73
+    Turnip 470.83
+    Strawberry 240.83
+    Mint 535.14
+    Broccoli 332.13
+    Thyme 580.08
+    Kale 391.05
+    Peach 496.14
+    Plum 480.05
+    Radish 90.74
+    Collard_Greens 556.94
+    Acorn_Squash 259.77
+    Starfruit 503.62
+    Dragon_Fruit 761.50
+    Papaya 292.90
+    Parsley 699.40
+    Lemon 480.98
+    Lime 390.58
+    Okra 577.33
+    Rhubarb 348.42
+    Jackfruit 553.86
+    Peas 166.19
+    Squash_Blossom 530.14
+    Guava 492.72
+    Clementine 360.66
+    Goji_Berry 395.90
+    Rosemary 458.52
+    Brussels_Sprouts 257.57
+    Onion 506.46
+    Honeydew 1308.96
+    Cherry 187.92
+    Fig 979.81
+    Endive 609.76
+    Raspberry 341.51
+    Lettuce 572.85
+    Pumpkin 838.08
+    Pineapple 260.66
+    Rutabaga 398.59
+    Parsnip 610.37
+    Cauliflower 420.89
+    Eggplant 561.63
+    Artichoke 912.48
+    Chard 517.35
+    Currant 1029.97
+    Cactus_Pear 538.41
+    Cabbage 424.46
+    Cilantro 400.41
+    Celery 404.08
+    Nectarine 256.23
+    Basil 449.74
+    Potato 232.22
+    Green_Beans 337.57
+    Sage 630.13
+    Sidi_Slimane 50853.69
+    Endive 434.41
+    Goji_Berry 441.12
+    Plum 323.05
+    Apple 709.65
+    Apricot 666.68
+    Orange 161.30
+    Parsley 434.62
+    Watercress 438.71
+    Kiwano 153.17
+    Radish 551.84
+    Cantaloupe 1264.29
+    Broccoli 428.28
+    Guava 851.42
+    Honeydew 682.95
+    Nectarine 458.34
+    Artichoke 1044.00
+    Pumpkin 968.14
+    Ginger 861.03
+    Green_Beans 211.17
+    Coconut 844.44
+    Pomegranate 962.98
+    Pineapple 671.36
+    Basil 675.45
+    Clementine 401.68
+    Mint 487.28
+    Strawberry 663.79
+    Grapes 449.10
+    Bell_Pepper 641.19
+    Rosemary 583.00
+    Oregano 697.94
+    Eggplant 707.26
+    Thyme 606.13
+    Passion_Fruit 869.95
+    Kiwi 521.42
+    Grapefruit 476.83
+    Kohlrabi 375.85
+    Brussels_Sprouts 561.82
+    Cauliflower 872.32
+    Dragon_Fruit 416.35
+    Watermelon 477.96
+    Avocado 237.86
+    Rutabaga 203.69
+    Butternut_Squash 368.45
+    Cabbage 970.76
+    Carrot 446.75
+    Potato 461.81
+    Peach 540.24
+    Rhubarb 295.66
+    Banana 461.53
+    Papaya 595.33
+    Peas 591.93
+    Dill 217.74
+    Spinach 401.67
+    Beet 187.47
+    Celery 481.97
+    Raspberry 728.46
+    Lettuce 579.97
+    Cilantro 444.28
+    Pear 274.67
+    Lime 271.94
+    Fig 533.23
+    Cactus_Pear 655.86
+    Persimmon 402.59
+    Zucchini 618.91
+    Cherry 434.08
+    Chard 473.93
+    Jicama 572.00
+    Asparagus 639.48
+    Jackfruit 238.60
+    Date 424.06
+    Cucumber 278.03
+    Tomato 427.79
+    Okra 503.26
+    Sage 429.55
+    Parsnip 751.49
+    Blueberry 408.59
+    Collard_Greens 359.97
+    Sweet_Potato 553.30
+    Currant 723.78
+    Squash_Blossom 157.78
+    Salsify 736.41
+    Cranberry 1133.13
+    Blackberry 478.25
+    Yam 829.14
+    Bok_Choy 523.84
+    Lemon 691.16
+    Acorn_Squash 720.90
+    Mango 352.46
+    Onion 412.44
+    Kale 419.70
+    Turnip 851.80
+    Plantain 586.31
+    Garlic 386.79
+    Starfruit 334.63
+    Tarfaya 47880.22
+    Cherry 637.60
+    Broccoli 701.19
+    Squash_Blossom 417.12
+    Persimmon 426.94
+    Peach 516.82
+    Thyme 377.22
+    Chard 409.33
+    Garlic 602.24
+    Lemon 671.15
+    Bell_Pepper 386.53
+    Orange 365.06
+    Rhubarb 597.69
+    Dragon_Fruit 371.67
+    Fig 560.22
+    Coconut 1208.88
+    Radish 466.67
+    Cucumber 639.05
+    Zucchini 326.22
+    Butternut_Squash 514.47
+    Beet 729.73
+    Oregano 740.76
+    Jicama 194.60
+    Plum 208.40
+    Starfruit 401.79
+    Potato 245.10
+    Brussels_Sprouts 502.93
+    Kohlrabi 468.95
+    Cauliflower 299.83
+    Peas 332.22
+    Asparagus 468.86
+    Collard_Greens 412.19
+    Bok_Choy 398.19
+    Pumpkin 505.95
+    Kiwano 650.28
+    Onion 206.80
+    Ginger 545.62
+    Jackfruit 582.91
+    Cantaloupe 903.13
+    Goji_Berry 442.57
+    Parsley 598.08
+    Cilantro 521.55
+    Cactus_Pear 332.72
+    Watercress 359.94
+    Mint 514.50
+    Celery 381.66
+    Date 517.73
+    Blackberry 456.96
+    Watermelon 345.40
+    Avocado 91.88
+    Pear 575.11
+    Tomato 293.66
+    Kiwi 635.67
+    Grapes 400.60
+    Acorn_Squash 469.29
+    Carrot 549.86
+    Apricot 388.46
+    Grapefruit 723.84
+    Lettuce 600.68
+    Plantain 662.24
+    Okra 409.15
+    Spinach 398.92
+    Parsnip 593.88
+    Green_Beans 503.59
+    Yam 820.52
+    Salsify 858.79
+    Pomegranate 619.40
+    Sage 489.16
+    Mango 484.04
+    Passion_Fruit 270.59
+    Artichoke 789.61
+    Strawberry 564.14
+    Rosemary 127.81
+    Apple 852.12
+    Clementine 598.53
+    Endive 395.19
+    Honeydew 837.73
+    Sweet_Potato 713.41
+    Pineapple 411.99
+    Eggplant 400.29
+    Nectarine 543.25
+    Raspberry 575.90
+    Rutabaga 717.75
+    Turnip 802.74
+    Lime 484.20
+    Banana 396.42
+    Cabbage 608.90
+    Blueberry 533.30
+    Basil 739.08
+    Papaya 576.54
+    Cranberry 664.43
+    Guava 269.78
+    Dill 569.70
+    Kale 178.23
+    Currant 224.43
+    Marrakech 50758.32
+    Peach 367.92
+    Beet 407.16
+    Rutabaga 525.32
+    Celery 496.66
+    Blackberry 666.59
+    Lettuce 684.57
+    Sage 420.70
+    Mint 236.37
+    Turnip 763.02
+    Banana 614.93
+    Jicama 458.46
+    Kiwi 505.35
+    Dill 583.09
+    Clementine 702.37
+    Salsify 239.58
+    Okra 680.31
+    Bell_Pepper 830.37
+    Sweet_Potato 398.83
+    Onion 530.96
+    Potato 576.55
+    Papaya 754.35
+    Yam 615.83
+    Carrot 160.62
+    Coconut 1160.67
+    Ginger 586.59
+    Strawberry 632.84
+    Broccoli 523.70
+    Jackfruit 252.80
+    Kiwano 428.73
+    Grapes 515.08
+    Honeydew 1031.43
+    Kohlrabi 758.61
+    Watermelon 547.98
+    Parsley 699.09
+    Pear 490.84
+    Mango 654.70
+    Plantain 476.15
+    Currant 871.95
+    Persimmon 388.34
+    Collard_Greens 861.28
+    Apricot 678.24
+    Garlic 798.15
+    Apple 386.44
+    Goji_Berry 325.12
+    Kale 1084.44
+    Pumpkin 496.31
+    Cantaloupe 716.50
+    Raspberry 606.92
+    Parsnip 326.63
+    Pineapple 472.49
+    Blueberry 205.29
+    Cranberry 686.31
+    Watercress 475.10
+    Eggplant 533.66
+    Butternut_Squash 368.39
+    Orange 388.75
+    Tomato 587.98
+    Squash_Blossom 287.15
+    Lime 358.74
+    Oregano 185.94
+    Date 402.02
+    Cauliflower 522.09
+    Radish 400.69
+    Asparagus 420.81
+    Guava 256.38
+    Lemon 697.11
+    Starfruit 682.50
+    Dragon_Fruit 588.46
+    Endive 347.64
+    Grapefruit 152.84
+    Nectarine 326.80
+    Plum 801.44
+    Basil 533.42
+    Bok_Choy 456.47
+    Cabbage 327.93
+    Fig 357.31
+    Avocado 445.64
+    Artichoke 1117.11
+    Cucumber 150.24
+    Spinach 428.37
+    Brussels_Sprouts 622.56
+    Zucchini 460.41
+    Cactus_Pear 429.01
+    Chard 511.49
+    Cherry 620.63
+    Pomegranate 1175.27
+    Rosemary 363.45
+    Acorn_Squash 596.54
+    Passion_Fruit 421.00
+    Rhubarb 473.07
+    Peas 520.13
+    Thyme 653.34
+    Cilantro 813.99
+    Green_Beans 612.92
+    Moulay_Bousselham 48529.71
+    Blackberry 269.65
+    Acorn_Squash 467.00
+    Ginger 450.03
+    Plum 260.45
+    Beet 635.17
+    Goji_Berry 905.51
+    Squash_Blossom 459.31
+    Asparagus 555.69
+    Passion_Fruit 622.54
+    Okra 578.70
+    Cactus_Pear 471.45
+    Chard 533.62
+    Thyme 586.52
+    Raspberry 890.10
+    Cilantro 659.40
+    Brussels_Sprouts 213.53
+    Date 279.66
+    Jackfruit 483.92
+    Tomato 261.90
+    Salsify 483.80
+    Avocado 257.51
+    Lime 595.17
+    Cherry 246.68
+    Pineapple 210.19
+    Nectarine 720.46
+    Watermelon 576.12
+    Starfruit 733.21
+    Celery 454.39
+    Lettuce 707.42
+    Lemon 368.78
+    Green_Beans 432.76
+    Cantaloupe 1038.29
+    Broccoli 412.12
+    Blueberry 636.78
+    Basil 527.41
+    Parsnip 334.18
+    Clementine 291.60
+    Turnip 573.43
+    Apple 134.53
+    Fig 1046.32
+    Sweet_Potato 341.38
+    Cauliflower 313.42
+    Peas 253.59
+    Kiwi 564.29
+    Apricot 660.84
+    Parsley 362.54
+    Mango 563.01
+    Orange 628.77
+    Zucchini 396.46
+    Garlic 662.86
+    Strawberry 419.62
+    Pear 593.71
+    Kiwano 749.35
+    Honeydew 809.76
+    Bok_Choy 508.44
+    Rutabaga 473.47
+    Watercress 331.60
+    Banana 341.24
+    Guava 379.53
+    Carrot 171.23
+    Radish 614.86
+    Artichoke 888.48
+    Papaya 410.53
+    Rhubarb 702.41
+    Spinach 207.94
+    Onion 359.95
+    Endive 616.46
+    Peach 241.44
+    Rosemary 491.56
+    Mint 637.06
+    Cabbage 223.95
+    Potato 381.96
+    Sage 393.29
+    Dragon_Fruit 475.51
+    Coconut 1074.86
+    Jicama 376.00
+    Cranberry 779.43
+    Bell_Pepper 265.75
+    Butternut_Squash 801.15
+    Eggplant 716.54
+    Pumpkin 361.96
+    Currant 854.17
+    Persimmon 489.02
+    Pomegranate 1173.32
+    Grapes 1019.84
+    Yam 472.73
+    Kale 521.44
+    Dill 660.18
+    Grapefruit 229.79
+    Plantain 517.93
+    Kohlrabi 654.29
+    Collard_Greens 194.14
+    Cucumber 439.93
+    Oregano 391.43
+    had_soualem 47654.07
+    Lettuce 536.04
+    Cactus_Pear 649.42
+    Pineapple 327.43
+    Brussels_Sprouts 459.54
+    Kohlrabi 463.08
+    Collard_Greens 374.76
+    Avocado 897.66
+    Dragon_Fruit 653.40
+    Kiwano 777.13
+    Cabbage 534.89
+    Pomegranate 1205.17
+    Turnip 427.73
+    Rutabaga 320.54
+    Plum 265.93
+    Tomato 654.97
+    Goji_Berry 211.38
+    Onion 553.39
+    Dill 211.95
+    Strawberry 431.89
+    Cranberry 1118.57
+    Asparagus 236.30
+    Rhubarb 562.12
+    Zucchini 273.67
+    Spinach 441.12
+    Acorn_Squash 420.39
+    Pumpkin 520.36
+    Okra 625.85
+    Mint 431.54
+    Jackfruit 563.79
+    Apricot 785.39
+    Thyme 556.91
+    Radish 539.70
+    Kale 541.43
+    Peas 390.25
+    Oregano 464.72
+    Endive 512.61
+    Rosemary 425.28
+    Butternut_Squash 481.70
+    Salsify 476.83
+    Carrot 528.12
+    Grapefruit 448.82
+    Basil 298.21
+    Watermelon 74.21
+    Date 367.91
+    Blueberry 468.45
+    Persimmon 358.12
+    Celery 716.51
+    Jicama 584.56
+    Artichoke 967.85
+    Papaya 506.19
+    Nectarine 564.64
+    Mango 611.76
+    Cauliflower 453.55
+    Potato 355.65
+    Beet 272.53
+    Lime 228.50
+    Fig 381.84
+    Cantaloupe 1172.00
+    Bell_Pepper 494.46
+    Guava 409.44
+    Cilantro 665.07
+    Pear 528.43
+    Honeydew 1021.50
+    Passion_Fruit 460.22
+    Lemon 538.77
+    Raspberry 430.88
+    Parsley 358.00
+    Coconut 1141.45
+    Green_Beans 406.17
+    Peach 374.11
+    Cucumber 707.19
+    Kiwi 234.18
+    Eggplant 380.07
+    Orange 645.12
+    Currant 366.93
+    Clementine 637.99
+    Ginger 296.27
+    Sweet_Potato 561.70
+    Apple 387.77
+    Sage 346.03
+    Broccoli 472.54
+    Chard 239.16
+    Banana 375.06
+    Bok_Choy 691.89
+    Squash_Blossom 319.97
+    Grapes 421.19
+    Garlic 222.27
+    Parsnip 507.51
+    Cherry 484.75
+    Plantain 710.08
+    Watercress 428.46
+    Yam 295.38
+    Starfruit 854.97
+    Blackberry 554.84
+    Larache 50679.85
+    Ginger 496.24
+    Zucchini 217.20
+    Thyme 263.07
+    Acorn_Squash 700.40
+    Peach 589.46
+    Turnip 376.83
+    Grapes 397.83
+    Rutabaga 717.58
+    Eggplant 492.87
+    Spinach 448.00
+    Squash_Blossom 819.80
+    Cherry 371.75
+    Carrot 670.43
+    Parsnip 338.96
+    Passion_Fruit 286.05
+    Raspberry 646.51
+    Blueberry 771.87
+    Basil 572.33
+    Peas 552.66
+    Tomato 579.55
+    Persimmon 401.23
+    Kiwi 338.70
+    Coconut 1396.37
+    Pomegranate 925.25
+    Papaya 720.37
+    Grapefruit 239.26
+    Date 456.27
+    Blackberry 242.97
+    Cactus_Pear 105.17
+    Okra 489.20
+    Jackfruit 395.24
+    Watercress 331.75
+    Cilantro 287.23
+    Plum 468.67
+    Green_Beans 249.11
+    Onion 353.68
+    Currant 555.24
+    Cantaloupe 829.64
+    Potato 228.88
+    Cauliflower 422.27
+    Sweet_Potato 693.69
+    Salsify 538.27
+    Dragon_Fruit 577.09
+    Fig 380.92
+    Lettuce 158.64
+    Garlic 221.54
+    Yam 421.79
+    Rosemary 384.24
+    Apple 606.81
+    Strawberry 396.39
+    Endive 571.98
+    Brussels_Sprouts 798.30
+    Pear 486.69
+    Kohlrabi 367.07
+    Celery 287.76
+    Kale 888.30
+    Honeydew 1116.63
+    Butternut_Squash 362.60
+    Cucumber 645.10
+    Bell_Pepper 859.05
+    Parsley 474.35
+    Kiwano 334.64
+    Sage 620.88
+    Pineapple 1087.05
+    Plantain 408.93
+    Collard_Greens 499.68
+    Orange 369.40
+    Lemon 450.77
+    Banana 242.63
+    Dill 755.46
+    Watermelon 409.84
+    Mango 333.07
+    Cabbage 388.07
+    Artichoke 1210.03
+    Clementine 861.79
+    Mint 506.70
+    Broccoli 579.86
+    Cranberry 976.25
+    Lime 808.62
+    Radish 577.18
+    Nectarine 889.40
+    Chard 759.68
+    Pumpkin 507.91
+    Goji_Berry 465.13
+    Asparagus 595.41
+    Jicama 688.34
+    Bok_Choy 738.15
+    Apricot 233.39
+    Starfruit 447.42
+    Rhubarb 928.09
+    Beet 416.55
+    Guava 375.38
+    Avocado 526.89
+    Oregano 704.16
+    Laayoune 50898.83
+    Onion 618.94
+    Peach 601.25
+    Orange 704.60
+    Rosemary 348.70
+    Kohlrabi 551.68
+    Grapes 353.47
+    Clementine 338.75
+    Brussels_Sprouts 376.58
+    Lemon 487.94
+    Pomegranate 1331.69
+    Passion_Fruit 406.15
+    Cantaloupe 1411.64
+    Parsley 685.11
+    Mint 326.63
+    Bell_Pepper 307.55
+    Garlic 487.23
+    Watermelon 490.09
+    Persimmon 651.55
+    Banana 341.17
+    Kiwano 571.96
+    Rhubarb 503.49
+    Cactus_Pear 406.84
+    Jicama 344.06
+    Lime 1091.11
+    Cucumber 439.86
+    Parsnip 815.02
+    Papaya 829.11
+    Watercress 630.97
+    Plantain 666.37
+    Beet 388.32
+    Guava 444.61
+    Basil 639.92
+    Bok_Choy 415.12
+    Potato 712.92
+    Cabbage 518.56
+    Apricot 417.25
+    Cauliflower 389.57
+    Acorn_Squash 404.53
+    Cilantro 529.93
+    Endive 425.80
+    Squash_Blossom 658.64
+    Green_Beans 234.32
+    Dragon_Fruit 362.28
+    Avocado 588.44
+    Spinach 501.27
+    Strawberry 699.00
+    Goji_Berry 579.58
+    Coconut 832.18
+    Asparagus 674.85
+    Kale 484.53
+    Turnip 330.78
+    Carrot 510.26
+    Peas 596.90
+    Dill 455.74
+    Sweet_Potato 463.31
+    Thyme 459.57
+    Collard_Greens 447.11
+    Starfruit 55.11
+    Fig 224.95
+    Cherry 691.88
+    Salsify 411.60
+    Cranberry 1244.12
+    Pear 653.79
+    Sage 531.11
+    Raspberry 406.27
+    Grapefruit 612.84
+    Mango 579.68
+    Blackberry 597.35
+    Apple 436.68
+    Lettuce 596.48
+    Ginger 565.99
+    Blueberry 441.27
+    Kiwi 584.38
+    Currant 363.29
+    Tomato 455.76
+    Artichoke 1201.22
+    Radish 614.27
+    Jackfruit 412.10
+    Zucchini 417.72
+    Chard 678.68
+    Broccoli 289.07
+    Date 651.65
+    Butternut_Squash 340.53
+    Oregano 369.58
+    Pumpkin 453.92
+    Pineapple 361.42
+    Eggplant 395.05
+    Okra 659.93
+    Plum 573.55
+    Rutabaga 537.57
+    Honeydew 1063.82
+    Yam 408.16
+    Nectarine 420.19
+    Celery 313.05
+    Béni_Mellal 50413.33
+    Butternut_Squash 431.05
+    Plum 654.22
+    Bok_Choy 830.70
+    Clementine 419.70
+    Basil 460.23
+    Eggplant 316.23
+    Spinach 533.09
+    Cantaloupe 1298.03
+    Kohlrabi 492.57
+    Starfruit 256.45
+    Tomato 301.24
+    Cherry 449.40
+    Broccoli 205.57
+    Lemon 542.69
+    Rosemary 69.18
+    Rhubarb 387.07
+    Mango 620.46
+    Carrot 880.97
+    Dill 473.65
+    Peas 791.81
+    Cucumber 508.57
+    Yam 475.82
+    Collard_Greens 287.22
+    Pineapple 444.04
+    Orange 731.38
+    Chard 373.79
+    Apricot 566.39
+    Watermelon 588.50
+    Apple 346.11
+    Blueberry 494.35
+    Thyme 435.93
+    Dragon_Fruit 349.91
+    Kale 672.60
+    Coconut 1071.34
+    Kiwi 725.90
+    Salsify 526.81
+    Grapes 338.40
+    Asparagus 539.26
+    Parsley 496.32
+    Lettuce 228.26
+    Rutabaga 689.89
+    Avocado 557.44
+    Nectarine 264.48
+    Kiwano 243.05
+    Strawberry 406.51
+    Pomegranate 1073.99
+    Papaya 248.52
+    Onion 411.35
+    Celery 509.26
+    Plantain 546.88
+    Garlic 324.20
+    Artichoke 892.67
+    Lime 744.20
+    Guava 724.48
+    Turnip 567.27
+    Persimmon 338.68
+    Pumpkin 132.56
+    Green_Beans 469.91
+    Bell_Pepper 566.13
+    Acorn_Squash 872.76
+    Parsnip 592.56
+    Zucchini 485.03
+    Raspberry 435.78
+    Jackfruit 719.81
+    Watercress 774.86
+    Sweet_Potato 370.25
+    Cilantro 266.11
+    Blackberry 688.42
+    Peach 524.71
+    Brussels_Sprouts 466.47
+    Grapefruit 454.32
+    Honeydew 1037.55
+    Pear 399.03
+    Mint 332.72
+    Ginger 371.83
+    Beet 672.81
+    Cauliflower 404.97
+    Radish 363.66
+    Oregano 677.67
+    Date 720.94
+    Cactus_Pear 340.28
+    Squash_Blossom 748.35
+    Passion_Fruit 355.60
+    Okra 578.53
+    Sage 749.02
+    Cranberry 1277.93
+    Fig 571.43
+    Goji_Berry 508.48
+    Endive 460.37
+    Cabbage 835.86
+    Currant 332.04
+    Banana 826.28
+    Potato 371.66
+    Jicama 498.56
+    Al_Hoceima 46691.12
+    Honeydew 807.03
+    Pear 418.44
+    Grapefruit 571.27
+    Yam 603.44
+    Pineapple 897.37
+    Jicama 400.48
+    Plantain 571.24
+    Turnip 651.38
+    Rosemary 653.26
+    Apple 435.70
+    Cucumber 195.61
+    Brussels_Sprouts 86.61
+    Basil 505.43
+    Strawberry 509.16
+    Kiwano 618.06
+    Dill 379.19
+    Lettuce 342.06
+    Collard_Greens 644.49
+    Jackfruit 654.05
+    Garlic 430.95
+    Orange 506.37
+    Date 409.17
+    Pomegranate 1020.82
+    Pumpkin 535.62
+    Persimmon 894.42
+    Sweet_Potato 592.09
+    Green_Beans 629.78
+    Butternut_Squash 639.79
+    Blueberry 116.96
+    Cherry 187.08
+    Mango 255.70
+    Dragon_Fruit 407.39
+    Parsnip 324.02
+    Tomato 455.66
+    Asparagus 360.89
+    Nectarine 280.31
+    Squash_Blossom 590.15
+    Celery 937.48
+    Salsify 312.00
+    Oregano 456.07
+    Kiwi 830.33
+    Artichoke 1199.32
+    Potato 203.97
+    Thyme 323.43
+    Bell_Pepper 612.46
+    Rhubarb 470.63
+    Passion_Fruit 301.06
+    Peach 722.14
+    Raspberry 401.64
+    Endive 269.11
+    Watermelon 342.98
+    Avocado 627.38
+    Beet 162.30
+    Coconut 893.52
+    Eggplant 531.68
+    Ginger 474.72
+    Acorn_Squash 440.87
+    Okra 458.11
+    Cactus_Pear 618.76
+    Cauliflower 523.15
+    Cantaloupe 1087.22
+    Fig 584.79
+    Carrot 343.23
+    Spinach 452.23
+    Radish 205.45
+    Kale 215.37
+    Goji_Berry 696.01
+    Kohlrabi 553.99
+    Clementine 348.05
+    Papaya 296.24
+    Apricot 720.87
+    Peas 451.86
+    Watercress 343.65
+    Sage 665.69
+    Banana 207.02
+    Lime 366.03
+    Chard 137.81
+    Lemon 166.76
+    Cilantro 502.47
+    Bok_Choy 602.93
+    Broccoli 936.18
+    Rutabaga 349.97
+    Currant 467.54
+    Blackberry 455.29
+    Grapes 199.18
+    Plum 448.86
+    Starfruit 172.54
+    Cabbage 458.03
+    Parsley 398.61
+    Cranberry 827.02
+    Mint 412.22
+    Guava 478.63
+    Zucchini 240.99
+    Onion 1203.84
+    Tan-Tan 49402.41
+    Carrot 772.00
+    Raspberry 234.44
+    Tomato 699.26
+    Persimmon 327.25
+    Cranberry 1203.78
+    Chard 848.76
+    Radish 860.98
+    Cabbage 443.67
+    Acorn_Squash 551.75
+    Plum 370.01
+    Mango 531.01
+    Oregano 572.57
+    Dill 720.67
+    Pineapple 857.56
+    Yam 416.01
+    Parsnip 373.01
+    Spinach 296.76
+    Peas 412.23
+    Okra 546.96
+    Kale 200.77
+    Bell_Pepper 426.83
+    Apricot 669.61
+    Kiwi 546.12
+    Passion_Fruit 377.93
+    Strawberry 686.18
+    Nectarine 269.37
+    Blackberry 443.82
+    Garlic 469.77
+    Celery 514.44
+    Brussels_Sprouts 490.85
+    Pomegranate 1064.39
+    Cauliflower 998.74
+    Papaya 396.54
+    Blueberry 516.21
+    Peach 409.04
+    Mint 366.95
+    Sweet_Potato 818.45
+    Watermelon 629.45
+    Asparagus 502.29
+    Coconut 869.69
+    Collard_Greens 199.16
+    Fig 293.87
+    Thyme 557.35
+    Endive 327.85
+    Kiwano 862.81
+    Avocado 478.08
+    Date 420.69
+    Honeydew 794.00
+    Turnip 754.98
+    Broccoli 711.55
+    Grapes 634.57
+    Butternut_Squash 721.42
+    Artichoke 1237.56
+    Cantaloupe 1149.02
+    Currant 402.99
+    Ginger 550.52
+    Guava 877.86
+    Banana 504.21
+    Lemon 444.28
+    Beet 439.54
+    Cactus_Pear 389.30
+    Potato 437.98
+    Squash_Blossom 280.05
+    Onion 298.77
+    Dragon_Fruit 454.94
+    Bok_Choy 589.63
+    Lime 331.06
+    Orange 628.91
+    Parsley 244.06
+    Green_Beans 292.23
+    Sage 398.74
+    Cucumber 437.31
+    Watercress 373.37
+    Jicama 352.55
+    Cherry 442.43
+    Apple 630.82
+    Lettuce 460.17
+    Pear 410.40
+    Rosemary 560.63
+    Kohlrabi 701.67
+    Goji_Berry 322.42
+    Grapefruit 514.58
+    Starfruit 284.11
+    Zucchini 274.44
+    Rhubarb 465.45
+    Plantain 304.32
+    Cilantro 630.91
+    Eggplant 499.06
+    Basil 351.88
+    Clementine 216.11
+    Jackfruit 565.27
+    Salsify 218.20
+    Pumpkin 490.48
+    Rutabaga 481.73
+    Settat 46254.38
+    Kale 416.55
+    Celery 394.56
+    Goji_Berry 336.85
+    Guava 223.38
+    Plum 780.21
+    Artichoke 912.26
+    Sweet_Potato 310.95
+    Grapefruit 175.28
+    Watermelon 304.00
+    Bell_Pepper 531.10
+    Strawberry 549.35
+    Honeydew 951.97
+    Dragon_Fruit 492.36
+    Cactus_Pear 293.79
+    Thyme 505.48
+    Lemon 427.93
+    Butternut_Squash 447.41
+    Cauliflower 911.70
+    Green_Beans 336.42
+    Carrot 481.86
+    Watercress 405.59
+    Grapes 322.25
+    Kiwano 585.72
+    Parsley 453.89
+    Passion_Fruit 413.71
+    Pineapple 336.33
+    Sage 268.68
+    Peach 745.23
+    Banana 501.62
+    Cherry 316.92
+    Orange 472.67
+    Dill 267.58
+    Chard 243.10
+    Yam 1020.83
+    Radish 427.24
+    Date 141.23
+    Kiwi 708.12
+    Blackberry 619.00
+    Brussels_Sprouts 719.24
+    Avocado 283.29
+    Raspberry 237.14
+    Ginger 298.59
+    Eggplant 368.72
+    Potato 758.17
+    Blueberry 545.33
+    Cucumber 683.32
+    Jicama 154.37
+    Rosemary 642.71
+    Peas 235.53
+    Coconut 1066.22
+    Salsify 393.65
+    Collard_Greens 203.74
+    Basil 538.01
+    Okra 264.72
+    Tomato 669.67
+    Garlic 360.81
+    Plantain 437.40
+    Pomegranate 1404.06
+    Cabbage 551.17
+    Rhubarb 674.69
+    Endive 546.57
+    Starfruit 248.64
+    Oregano 400.98
+    Spinach 289.04
+    Jackfruit 548.93
+    Apricot 286.07
+    Parsnip 264.67
+    Zucchini 673.44
+    Pumpkin 169.68
+    Apple 301.51
+    Bok_Choy 363.01
+    Turnip 129.36
+    Lime 434.42
+    Currant 352.65
+    Cantaloupe 654.83
+    Pear 408.26
+    Clementine 521.00
+    Squash_Blossom 985.30
+    Broccoli 661.09
+    Fig 903.45
+    Beet 476.83
+    Persimmon 270.81
+    Onion 561.20
+    Rutabaga 771.72
+    Lettuce 823.95
+    Kohlrabi 685.18
+    Acorn_Squash 333.03
+    Papaya 282.20
+    Cilantro 601.89
+    Mint 594.09
+    Asparagus 498.06
+    Nectarine 285.07
+    Cranberry 853.36
+    Mango 550.42
+    Bni_Hadifa 49167.94
+    Acorn_Squash 892.78
+    Bell_Pepper 245.11
+    Apricot 354.61
+    Pineapple 296.98
+    Chard 441.65
+    Rutabaga 756.90
+    Eggplant 628.17
+    Endive 381.24
+    Oregano 463.76
+    Strawberry 472.02
+    Sweet_Potato 432.07
+    Collard_Greens 365.08
+    Watermelon 450.52
+    Cabbage 690.42
+    Jackfruit 613.07
+    Persimmon 325.75
+    Yam 199.45
+    Goji_Berry 195.45
+    Cactus_Pear 766.85
+    Mango 340.96
+    Nectarine 390.87
+    Turnip 324.55
+    Peach 401.73
+    Mint 704.27
+    Blueberry 451.07
+    Fig 978.10
+    Dill 508.03
+    Peas 736.36
+    Dragon_Fruit 521.56
+    Raspberry 419.68
+    Artichoke 910.84
+    Plantain 467.70
+    Kohlrabi 587.52
+    Radish 442.42
+    Asparagus 723.30
+    Pomegranate 996.33
+    Grapefruit 491.94
+    Squash_Blossom 460.81
+    Celery 242.85
+    Rhubarb 321.38
+    Pumpkin 643.07
+    Carrot 91.48
+    Thyme 589.45
+    Avocado 247.72
+    Okra 688.11
+    Potato 557.48
+    Honeydew 865.47
+    Clementine 382.74
+    Zucchini 460.75
+    Broccoli 242.89
+    Beet 666.78
+    Cherry 404.92
+    Green_Beans 1233.76
+    Papaya 467.86
+    Parsnip 295.05
+    Date 301.15
+    Plum 534.51
+    Kale 743.77
+    Coconut 1380.75
+    Garlic 552.37
+    Sage 693.42
+    Cauliflower 454.37
+    Spinach 144.10
+    Cucumber 707.92
+    Lime 399.33
+    Bok_Choy 308.49
+    Currant 541.02
+    Grapes 526.82
+    Guava 559.71
+    Kiwano 366.84
+    Passion_Fruit 486.27
+    Brussels_Sprouts 419.42
+    Tomato 534.54
+    Kiwi 187.45
+    Ginger 299.80
+    Banana 767.31
+    Basil 298.93
+    Pear 253.00
+    Cantaloupe 872.58
+    Watercress 289.06
+    Rosemary 415.97
+    Butternut_Squash 744.72
+    Salsify 607.92
+    Jicama 301.79
+    Blackberry 832.71
+    Parsley 583.96
+    Onion 323.99
+    Starfruit 402.65
+    Apple 329.52
+    Lettuce 587.59
+    Cilantro 938.13
+    Orange 721.81
+    Lemon 690.50
+    Cranberry 832.07
+    Assa 49644.76
+    Pomegranate 913.42
+    Blueberry 731.09
+    Blackberry 681.07
+    Clementine 460.71
+    Watercress 535.83
+    Apricot 297.11
+    Avocado 144.19
+    Artichoke 922.01
+    Kale 396.16
+    Ginger 639.54
+    Cauliflower 98.32
+    Papaya 285.05
+    Grapefruit 157.94
+    Currant 593.09
+    Kiwi 614.94
+    Pumpkin 364.38
+    Asparagus 440.19
+    Kohlrabi 245.47
+    Cantaloupe 988.30
+    Dill 535.51
+    Cherry 415.13
+    Honeydew 965.97
+    Cranberry 909.25
+    Nectarine 294.35
+    Radish 314.31
+    Oregano 600.63
+    Potato 513.26
+    Jicama 381.09
+    Eggplant 379.95
+    Pear 631.04
+    Broccoli 366.63
+    Chard 465.05
+    Endive 945.60
+    Lettuce 426.41
+    Parsnip 595.96
+    Rosemary 459.29
+    Salsify 783.13
+    Persimmon 338.64
+    Mint 541.61
+    Beet 997.49
+    Orange 343.35
+    Onion 277.53
+    Mango 605.74
+    Rutabaga 740.86
+    Bell_Pepper 388.69
+    Collard_Greens 510.46
+    Goji_Berry 729.20
+    Yam 196.90
+    Peach 439.18
+    Thyme 479.52
+    Cactus_Pear 395.29
+    Acorn_Squash 577.04
+    Garlic 685.37
+    Cilantro 983.33
+    Pineapple 421.07
+    Grapes 439.82
+    Tomato 478.69
+    Date 216.24
+    Banana 502.52
+    Kiwano 493.38
+    Fig 525.73
+    Squash_Blossom 423.26
+    Rhubarb 516.69
+    Carrot 785.63
+    Sage 711.64
+    Passion_Fruit 488.35
+    Raspberry 472.66
+    Spinach 966.66
+    Butternut_Squash 209.48
+    Starfruit 379.48
+    Cucumber 240.79
+    Sweet_Potato 459.79
+    Peas 623.53
+    Zucchini 853.18
+    Guava 319.67
+    Brussels_Sprouts 507.59
+    Turnip 664.24
+    Celery 453.23
+    Plum 335.01
+    Parsley 572.24
+    Cabbage 492.65
+    Coconut 950.15
+    Basil 392.25
+    Okra 487.09
+    Bok_Choy 266.75
+    Lemon 525.39
+    Lime 593.77
+    Watermelon 589.37
+    Dragon_Fruit 526.49
+    Plantain 834.63
+    Apple 610.21
+    Strawberry 636.62
+    Jackfruit 407.58
+    Green_Beans 549.67
+    Sidi_Ifni 49297.41
+    Pumpkin 213.36
+    Mint 410.26
+    Mango 508.69
+    Peach 343.22
+    Rutabaga 555.15
+    Guava 256.38
+    Salsify 511.20
+    Papaya 641.52
+    Yam 198.28
+    Tomato 272.13
+    Cherry 651.60
+    Jackfruit 402.35
+    Cactus_Pear 432.21
+    Green_Beans 735.76
+    Strawberry 242.76
+    Bell_Pepper 500.62
+    Clementine 567.37
+    Ginger 760.23
+    Lemon 160.96
+    Dragon_Fruit 200.68
+    Cranberry 937.22
+    Apple 612.69
+    Kiwano 403.23
+    Brussels_Sprouts 453.90
+    Parsnip 505.36
+    Broccoli 333.13
+    Honeydew 1207.81
+    Cauliflower 280.79
+    Blueberry 452.37
+    Butternut_Squash 648.15
+    Lettuce 659.19
+    Endive 398.35
+    Rosemary 623.20
+    Cabbage 686.84
+    Cilantro 301.36
+    Potato 534.64
+    Passion_Fruit 476.90
+    Nectarine 347.87
+    Cucumber 631.38
+    Kiwi 608.99
+    Turnip 408.65
+    Sage 690.15
+    Acorn_Squash 400.25
+    Dill 279.77
+    Thyme 251.64
+    Kohlrabi 338.12
+    Chard 489.67
+    Sweet_Potato 189.24
+    Bok_Choy 804.78
+    Raspberry 494.33
+    Carrot 659.45
+    Lime 296.55
+    Asparagus 342.07
+    Okra 685.64
+    Pomegranate 984.67
+    Pineapple 322.32
+    Plantain 753.81
+    Jicama 502.98
+    Coconut 1036.46
+    Rhubarb 512.38
+    Fig 667.70
+    Orange 553.97
+    Beet 560.55
+    Radish 426.04
+    Celery 302.48
+    Parsley 769.26
+    Grapefruit 940.98
+    Oregano 455.11
+    Cantaloupe 833.81
+    Plum 684.00
+    Apricot 493.59
+    Grapes 277.04
+    Avocado 435.02
+    Peas 543.11
+    Eggplant 769.16
+    Zucchini 399.68
+    Goji_Berry 538.00
+    Currant 607.54
+    Pear 292.92
+    Persimmon 817.03
+    Artichoke 926.97
+    Watermelon 551.26
+    Date 625.10
+    Spinach 422.10
+    Watercress 684.84
+    Kale 223.66
+    Garlic 664.82
+    Basil 470.70
+    Banana 679.06
+    Onion 340.29
+    Starfruit 558.21
+    Blackberry 711.08
+    Collard_Greens 441.82
+    Squash_Blossom 519.48
+    Tetouan 50054.30
+    Mango 371.08
+    Banana 218.79
+    Lime 371.36
+    Radish 897.42
+    Carrot 675.74
+    Jackfruit 506.16
+    Bell_Pepper 376.11
+    Apple 622.56
+    Pomegranate 851.80
+    Rosemary 786.73
+    Cauliflower 551.22
+    Tomato 649.67
+    Coconut 1184.57
+    Kale 639.10
+    Lemon 427.16
+    Currant 605.17
+    Mint 411.21
+    Strawberry 609.03
+    Parsley 589.06
+    Kiwano 679.73
+    Pear 408.35
+    Date 576.78
+    Cucumber 836.42
+    Zucchini 495.62
+    Guava 420.29
+    Raspberry 368.30
+    Cranberry 762.89
+    Onion 508.89
+    Watercress 541.46
+    Blueberry 619.92
+    Cilantro 582.53
+    Apricot 235.43
+    Oregano 439.20
+    Lettuce 771.59
+    Artichoke 735.48
+    Yam 698.86
+    Dragon_Fruit 383.52
+    Spinach 801.93
+    Bok_Choy 634.34
+    Grapes 361.43
+    Kiwi 503.28
+    Turnip 600.70
+    Sage 343.26
+    Endive 342.61
+    Asparagus 413.70
+    Fig 387.29
+    Thyme 492.75
+    Okra 202.86
+    Pineapple 445.86
+    Watermelon 330.89
+    Butternut_Squash 533.69
+    Orange 566.86
+    Cactus_Pear 488.39
+    Jicama 526.08
+    Acorn_Squash 295.24
+    Passion_Fruit 857.48
+    Kohlrabi 581.26
+    Grapefruit 170.44
+    Peas 350.85
+    Persimmon 624.60
+    Garlic 413.32
+    Rutabaga 752.26
+    Starfruit 159.28
+    Potato 423.31
+    Plantain 285.30
+    Beet 384.10
+    Broccoli 139.92
+    Honeydew 1085.47
+    Peach 438.56
+    Clementine 932.98
+    Plum 762.70
+    Collard_Greens 921.64
+    Celery 565.06
+    Green_Beans 497.03
+    Rhubarb 631.30
+    Parsnip 438.79
+    Basil 280.45
+    Blackberry 507.56
+    Pumpkin 471.41
+    Ginger 619.88
+    Brussels_Sprouts 443.06
+    Avocado 165.35
+    Goji_Berry 507.15
+    Sweet_Potato 306.25
+    Eggplant 558.66
+    Dill 348.88
+    Papaya 385.59
+    Cantaloupe 984.60
+    Nectarine 615.09
+    Cherry 476.67
+    Cabbage 571.07
+    Chard 621.20
+    Salsify 433.41
+    Squash_Blossom 662.01
+    Ouazzane 51854.88
+    Grapefruit 704.69
+    Salsify 1167.55
+    Garlic 351.08
+    Oregano 330.15
+    Okra 229.22
+    Kale 530.78
+    Plantain 639.90
+    Cactus_Pear 684.19
+    Bok_Choy 460.43
+    Honeydew 1021.12
+    Basil 272.46
+    Watermelon 530.62
+    Onion 506.50
+    Clementine 618.27
+    Persimmon 232.58
+    Blueberry 700.27
+    Spinach 524.77
+    Passion_Fruit 286.69
+    Carrot 350.74
+    Orange 367.01
+    Kiwano 258.74
+    Nectarine 991.84
+    Coconut 714.60
+    Chard 650.55
+    Rosemary 484.60
+    Cantaloupe 1138.84
+    Guava 277.15
+    Lemon 289.53
+    Banana 197.00
+    Lettuce 322.79
+    Ginger 505.01
+    Collard_Greens 264.49
+    Parsley 215.38
+    Goji_Berry 570.72
+    Avocado 1079.48
+    Mint 699.58
+    Blackberry 586.91
+    Strawberry 531.75
+    Mango 678.42
+    Cabbage 947.13
+    Cilantro 858.26
+    Cranberry 976.16
+    Potato 802.12
+    Rutabaga 363.09
+    Pineapple 309.97
+    Broccoli 514.89
+    Acorn_Squash 620.93
+    Currant 766.28
+    Kiwi 578.78
+    Peach 436.46
+    Butternut_Squash 345.36
+    Date 437.16
+    Pumpkin 494.41
+    Eggplant 604.86
+    Papaya 630.59
+    Tomato 194.65
+    Fig 514.98
+    Apricot 257.93
+    Plum 348.98
+    Brussels_Sprouts 819.75
+    Artichoke 775.78
+    Cherry 432.11
+    Celery 349.95
+    Radish 585.20
+    Endive 434.53
+    Watercress 603.54
+    Squash_Blossom 439.79
+    Jackfruit 606.06
+    Apple 738.92
+    Pear 392.71
+    Sweet_Potato 510.40
+    Parsnip 893.47
+    Cauliflower 519.85
+    Cucumber 542.36
+    Rhubarb 843.48
+    Turnip 303.75
+    Yam 349.33
+    Kohlrabi 596.07
+    Green_Beans 701.21
+    Jicama 719.57
+    Sage 686.08
+    Zucchini 431.78
+    Peas 447.39
+    Thyme 363.01
+    Beet 534.73
+    Starfruit 796.09
+    Grapes 456.64
+    Pomegranate 1109.96
+    Raspberry 466.01
+    Dill 547.64
+    Bell_Pepper 1052.93
+    Asparagus 343.98
+    Lime 208.46
+    Dragon_Fruit 282.96
+    Taroudant 49406.35
+    Fig 483.77
+    Honeydew 1378.53
+    Beet 476.12
+    Celery 617.85
+    Persimmon 186.96
+    Peach 265.31
+    Jicama 550.69
+    Cantaloupe 1199.24
+    Butternut_Squash 367.80
+    Raspberry 161.80
+    Green_Beans 396.14
+    Bell_Pepper 739.91
+    Endive 724.08
+    Goji_Berry 367.46
+    Brussels_Sprouts 994.45
+    Peas 326.77
+    Ginger 911.30
+    Plantain 398.69
+    Blueberry 311.13
+    Grapes 341.64
+    Eggplant 504.71
+    Collard_Greens 401.44
+    Date 737.24
+    Okra 461.00
+    Kohlrabi 378.23
+    Nectarine 497.73
+    Plum 382.30
+    Clementine 539.33
+    Radish 512.65
+    Mint 672.48
+    Potato 654.08
+    Mango 171.51
+    Lemon 551.52
+    Rutabaga 689.58
+    Apple 455.67
+    Garlic 421.71
+    Rosemary 457.65
+    Watermelon 460.44
+    Currant 606.62
+    Watercress 600.46
+    Chard 605.77
+    Cactus_Pear 551.19
+    Tomato 197.71
+    Pomegranate 836.75
+    Papaya 131.75
+    Coconut 883.18
+    Orange 373.68
+    Yam 578.85
+    Asparagus 392.89
+    Lettuce 450.70
+    Parsnip 428.25
+    Broccoli 384.12
+    Cilantro 189.91
+    Cranberry 1041.62
+    Blackberry 655.48
+    Turnip 417.43
+    Dill 520.05
+    Cauliflower 640.97
+    Salsify 774.52
+    Jackfruit 620.26
+    Zucchini 1102.51
+    Spinach 513.89
+    Apricot 359.81
+    Sage 650.14
+    Passion_Fruit 793.46
+    Sweet_Potato 374.73
+    Kiwi 352.42
+    Cabbage 648.02
+    Rhubarb 368.11
+    Dragon_Fruit 699.28
+    Onion 453.13
+    Grapefruit 331.54
+    Carrot 445.39
+    Lime 307.73
+    Parsley 320.09
+    Bok_Choy 532.08
+    Kale 487.90
+    Acorn_Squash 386.67
+    Pineapple 165.66
+    Banana 189.71
+    Cherry 467.69
+    Oregano 576.99
+    Pumpkin 946.88
+    Kiwano 550.06
+    Thyme 842.36
+    Pear 255.60
+    Starfruit 359.25
+    Strawberry 544.51
+    Basil 746.34
+    Artichoke 851.29
+    Cucumber 553.45
+    Avocado 423.61
+    Guava 668.92
+    Squash_Blossom 106.06
+    Khenifra 50610.14
+    Lemon 555.95
+    Cactus_Pear 727.31
+    Cantaloupe 1477.92
+    Cilantro 515.60
+    Onion 512.34
+    Watercress 391.78
+    Passion_Fruit 489.66
+    Currant 501.51
+    Yam 755.00
+    Cranberry 1257.87
+    Clementine 500.45
+    Cucumber 528.86
+    Honeydew 1142.59
+    Squash_Blossom 297.83
+    Rhubarb 373.88
+    Artichoke 864.28
+    Collard_Greens 840.55
+    Garlic 679.97
+    Oregano 780.11
+    Eggplant 546.77
+    Asparagus 489.42
+    Banana 474.10
+    Goji_Berry 871.75
+    Plum 405.63
+    Parsley 449.41
+    Grapes 447.29
+    Zucchini 723.76
+    Sweet_Potato 224.79
+    Parsnip 501.62
+    Avocado 473.72
+    Nectarine 655.06
+    Bell_Pepper 402.02
+    Endive 538.64
+    Pumpkin 523.62
+    Raspberry 714.98
+    Dragon_Fruit 645.79
+    Mango 344.41
+    Plantain 350.83
+    Blackberry 495.52
+    Peas 414.91
+    Bok_Choy 453.72
+    Strawberry 315.48
+    Pear 619.59
+    Okra 419.11
+    Chard 556.81
+    Date 540.05
+    Cherry 489.75
+    Broccoli 433.16
+    Radish 450.20
+    Apple 435.90
+    Orange 376.33
+    Jackfruit 386.04
+    Tomato 505.61
+    Kiwano 273.88
+    Kiwi 156.07
+    Persimmon 583.89
+    Fig 316.58
+    Guava 933.70
+    Carrot 435.28
+    Thyme 626.34
+    Butternut_Squash 366.90
+    Apricot 582.76
+    Lettuce 484.80
+    Mint 396.88
+    Acorn_Squash 951.60
+    Jicama 420.06
+    Spinach 521.81
+    Basil 515.40
+    Pineapple 470.80
+    Papaya 827.01
+    Coconut 853.22
+    Rutabaga 570.54
+    Kale 671.92
+    Cauliflower 177.01
+    Rosemary 603.62
+    Cabbage 274.69
+    Peach 347.69
+    Blueberry 510.18
+    Watermelon 689.90
+    Pomegranate 820.82
+    Kohlrabi 364.75
+    Green_Beans 277.90
+    Grapefruit 602.22
+    Sage 429.83
+    Salsify 263.43
+    Lime 504.78
+    Brussels_Sprouts 539.84
+    Beet 608.67
+    Starfruit 339.43
+    Turnip 590.11
+    Potato 202.79
+    Dill 403.68
+    Ginger 402.95
+    Celery 827.16
+    Sidi_Bennour 51961.47
+    Sweet_Potato 274.43
+    Squash_Blossom 324.32
+    Potato 430.77
+    Dill 416.36
+    Coconut 1233.69
+    Cabbage 907.14
+    Bell_Pepper 681.87
+    Garlic 706.78
+    Blueberry 883.73
+    Goji_Berry 413.79
+    Watercress 701.13
+    Cucumber 461.64
+    Peas 523.85
+    Cranberry 1464.66
+    Beet 428.08
+    Parsley 447.93
+    Tomato 624.16
+    Cactus_Pear 682.06
+    Persimmon 562.30
+    Pomegranate 966.78
+    Cherry 857.00
+    Strawberry 515.35
+    Asparagus 516.93
+    Bok_Choy 631.63
+    Artichoke 967.11
+    Basil 364.98
+    Sage 543.40
+    Thyme 611.27
+    Jackfruit 901.24
+    Pumpkin 543.75
+    Papaya 365.67
+    Lemon 415.25
+    Salsify 557.04
+    Kale 428.24
+    Radish 365.54
+    Kiwi 554.76
+    Acorn_Squash 615.33
+    Plum 448.42
+    Watermelon 759.91
+    Cantaloupe 726.12
+    Clementine 448.72
+    Fig 805.41
+    Butternut_Squash 465.52
+    Peach 868.95
+    Honeydew 376.81
+    Carrot 435.72
+    Oregano 581.63
+    Spinach 291.25
+    Apricot 767.12
+    Mint 990.19
+    Parsnip 700.95
+    Zucchini 561.55
+    Avocado 316.21
+    Brussels_Sprouts 672.50
+    Lime 893.46
+    Lettuce 353.64
+    Apple 225.75
+    Chard 820.78
+    Endive 699.41
+    Banana 285.97
+    Pear 465.95
+    Plantain 300.92
+    Okra 574.96
+    Eggplant 168.57
+    Green_Beans 448.24
+    Nectarine 511.66
+    Orange 145.78
+    Cauliflower 373.50
+    Guava 400.64
+    Rhubarb 502.63
+    Pineapple 520.36
+    Ginger 917.01
+    Kiwano 664.70
+    Kohlrabi 147.64
+    Onion 476.71
+    Celery 374.68
+    Blackberry 292.81
+    Date 889.28
+    Collard_Greens 531.22
+    Rutabaga 470.44
+    Cilantro 519.02
+    Starfruit 33.72
+    Jicama 702.28
+    Dragon_Fruit 467.25
+    Mango 303.29
+    Turnip 388.34
+    Passion_Fruit 432.09
+    Yam 411.50
+    Grapes 549.66
+    Broccoli 603.28
+    Grapefruit 431.86
+    Raspberry 503.45
+    Currant 474.72
+    Rosemary 577.36
+    Sefrou 47928.35
+    Cilantro 729.18
+    Eggplant 437.85
+    Ginger 287.23
+    Basil 543.87
+    Celery 697.38
+    Pomegranate 855.51
+    Pear 626.30
+    Dragon_Fruit 431.17
+    Honeydew 938.69
+    Mint 806.85
+    Raspberry 394.29
+    Lettuce 523.11
+    Parsnip 699.19
+    Blackberry 382.91
+    Jackfruit 647.90
+    Artichoke 734.27
+    Yam 384.66
+    Pineapple 426.59
+    Date 62.02
+    Broccoli 716.20
+    Rutabaga 122.16
+    Nectarine 522.89
+    Peas 683.13
+    Brussels_Sprouts 381.69
+    Blueberry 532.94
+    Asparagus 483.64
+    Apple 335.60
+    Plantain 235.66
+    Parsley 785.60
+    Spinach 372.98
+    Passion_Fruit 659.54
+    Cantaloupe 798.88
+    Plum 356.04
+    Butternut_Squash 544.63
+    Thyme 780.41
+    Oregano 509.84
+    Clementine 789.86
+    Lemon 316.74
+    Mango 427.50
+    Endive 387.90
+    Cucumber 663.61
+    Turnip 476.56
+    Chard 488.71
+    Lime 432.83
+    Cactus_Pear 472.14
+    Cabbage 231.54
+    Cauliflower 279.12
+    Sage 336.48
+    Collard_Greens 795.44
+    Kohlrabi 188.23
+    Garlic 462.19
+    Grapes 462.26
+    Sweet_Potato 541.73
+    Rhubarb 571.00
+    Watercress 688.32
+    Grapefruit 227.43
+    Avocado 522.07
+    Banana 366.71
+    Goji_Berry 660.92
+    Zucchini 388.43
+    Apricot 612.56
+    Orange 290.12
+    Strawberry 528.74
+    Kale 517.24
+    Cherry 442.53
+    Papaya 312.31
+    Bell_Pepper 471.19
+    Okra 493.77
+    Starfruit 549.88
+    Bok_Choy 371.96
+    Acorn_Squash 886.06
+    Coconut 977.66
+    Green_Beans 243.84
+    Squash_Blossom 313.18
+    Onion 392.69
+    Peach 475.05
+    Watermelon 455.93
+    Dill 575.58
+    Beet 582.43
+    Salsify 599.26
+    Guava 740.09
+    Kiwi 357.95
+    Pumpkin 532.76
+    Currant 493.63
+    Kiwano 457.16
+    Fig 652.49
+    Potato 328.35
+    Tomato 243.32
+    Carrot 305.81
+    Cranberry 990.21
+    Radish 799.91
+    Jicama 343.34
+    Rosemary 757.76
+    Persimmon 225.07
+    Bir_Lehlou 50770.75
+    Cabbage 576.06
+    Apricot 720.85
+    Kiwi 539.08
+    Cherry 538.18
+    Persimmon 464.56
+    Zucchini 542.43
+    Kohlrabi 319.79
+    Jicama 304.17
+    Pomegranate 1484.06
+    Brussels_Sprouts 506.35
+    Rosemary 596.75
+    Bok_Choy 397.72
+    Kale 609.99
+    Peach 492.01
+    Celery 261.31
+    Watercress 265.39
+    Parsley 591.61
+    Oregano 529.15
+    Endive 617.54
+    Guava 522.49
+    Tomato 495.67
+    Goji_Berry 520.22
+    Coconut 778.38
+    Cucumber 668.18
+    Basil 397.62
+    Cranberry 1183.35
+    Eggplant 238.18
+    Parsnip 419.85
+    Lemon 320.65
+    Artichoke 1240.50
+    Potato 873.67
+    Pumpkin 557.84
+    Fig 396.49
+    Cilantro 288.12
+    Plantain 736.37
+    Strawberry 433.84
+    Passion_Fruit 269.91
+    Mint 907.47
+    Bell_Pepper 649.99
+    Jackfruit 192.33
+    Thyme 661.53
+    Raspberry 390.10
+    Blackberry 658.14
+    Garlic 739.12
+    Butternut_Squash 729.32
+    Banana 400.17
+    Broccoli 390.41
+    Turnip 427.81
+    Dill 712.89
+    Grapes 281.30
+    Squash_Blossom 454.29
+    Blueberry 333.32
+    Rutabaga 316.64
+    Cactus_Pear 424.79
+    Rhubarb 503.22
+    Asparagus 405.78
+    Cantaloupe 1026.89
+    Grapefruit 522.82
+    Green_Beans 707.92
+    Starfruit 687.04
+    Lettuce 557.47
+    Radish 883.49
+    Currant 462.61
+    Dragon_Fruit 337.07
+    Honeydew 854.83
+    Plum 594.97
+    Nectarine 567.57
+    Collard_Greens 687.18
+    Clementine 583.12
+    Yam 295.18
+    Papaya 501.95
+    Beet 596.51
+    Date 691.02
+    Chard 279.00
+    Kiwano 780.41
+    Pear 116.36
+    Cauliflower 767.29
+    Peas 426.40
+    Acorn_Squash 447.18
+    Ginger 431.35
+    Onion 579.51
+    Pineapple 246.53
+    Sage 563.25
+    Apple 379.92
+    Salsify 756.35
+    Lime 327.30
+    Spinach 745.20
+    Orange 285.47
+    Sweet_Potato 536.77
+    Avocado 426.31
+    Carrot 654.27
+    Okra 317.39
+    Mango 267.07
+    Watermelon 602.83
+    Tiflet 52212.93
+    Cilantro 843.07
+    Cucumber 451.68
+    Endive 575.17
+    Cactus_Pear 626.29
+    Acorn_Squash 648.17
+    Blackberry 518.43
+    Watercress 830.06
+    Date 670.05
+    Rhubarb 527.87
+    Rutabaga 390.53
+    Beet 221.00
+    Fig 499.86
+    Cauliflower 569.32
+    Cantaloupe 877.78
+    Squash_Blossom 685.11
+    Butternut_Squash 613.91
+    Pomegranate 918.45
+    Tomato 680.80
+    Kiwi 466.56
+    Kohlrabi 216.31
+    Lemon 346.20
+    Carrot 554.35
+    Yam 508.85
+    Plantain 281.20
+    Peach 513.55
+    Cranberry 1068.25
+    Starfruit 355.12
+    Rosemary 418.28
+    Radish 426.13
+    Persimmon 657.56
+    Jicama 640.35
+    Bok_Choy 393.34
+    Eggplant 241.27
+    Sweet_Potato 447.12
+    Blueberry 575.22
+    Onion 341.68
+    Clementine 661.40
+    Lettuce 758.16
+    Thyme 417.01
+    Coconut 543.48
+    Strawberry 774.32
+    Lime 376.42
+    Peas 517.79
+    Potato 722.98
+    Salsify 522.14
+    Raspberry 554.26
+    Basil 651.99
+    Goji_Berry 718.82
+    Orange 279.16
+    Green_Beans 518.28
+    Honeydew 783.43
+    Asparagus 946.15
+    Oregano 380.25
+    Dragon_Fruit 406.69
+    Dill 538.34
+    Zucchini 254.86
+    Kale 835.26
+    Pumpkin 831.35
+    Nectarine 351.50
+    Pineapple 741.37
+    Garlic 474.34
+    Brussels_Sprouts 566.55
+    Apple 613.42
+    Artichoke 526.09
+    Apricot 710.84
+    Banana 639.36
+    Pear 578.72
+    Ginger 572.57
+    Collard_Greens 570.51
+    Guava 675.11
+    Spinach 640.35
+    Jackfruit 766.43
+    Kiwano 523.44
+    Watermelon 460.90
+    Parsnip 652.73
+    Turnip 298.67
+    Mango 468.37
+    Chard 387.30
+    Grapes 528.95
+    Broccoli 565.58
+    Parsley 405.40
+    Bell_Pepper 864.90
+    Avocado 485.28
+    Okra 499.47
+    Celery 564.75
+    Currant 430.68
+    Sage 448.99
+    Plum 667.00
+    Cabbage 499.62
+    Passion_Fruit 471.85
+    Cherry 111.65
+    Mint 696.15
+    Grapefruit 680.40
+    Papaya 482.26
+    Tichla 51839.64
+    Kiwano 117.56
+    Parsnip 345.88
+    Guava 551.92
+    Sweet_Potato 490.50
+    Blueberry 526.73
+    Radish 583.63
+    Carrot 489.57
+    Cantaloupe 1127.60
+    Oregano 136.53
+    Papaya 839.59
+    Cucumber 789.84
+    Watermelon 446.45
+    Celery 295.65
+    Lemon 508.41
+    Dill 827.07
+    Lime 395.39
+    Raspberry 371.10
+    Kiwi 283.91
+    Currant 594.40
+    Pineapple 310.55
+    Coconut 1262.89
+    Potato 337.55
+    Eggplant 456.73
+    Thyme 539.11
+    Grapefruit 316.31
+    Artichoke 667.48
+    Passion_Fruit 676.52
+    Yam 312.62
+    Green_Beans 576.79
+    Ginger 569.71
+    Cherry 175.52
+    Chard 527.25
+    Butternut_Squash 237.91
+    Starfruit 396.32
+    Broccoli 539.51
+    Dragon_Fruit 404.99
+    Zucchini 1050.54
+    Bell_Pepper 557.42
+    Watercress 280.50
+    Acorn_Squash 530.48
+    Rhubarb 243.69
+    Pumpkin 813.84
+    Apricot 596.23
+    Cabbage 740.09
+    Asparagus 671.82
+    Rosemary 331.06
+    Nectarine 536.12
+    Beet 787.05
+    Sage 484.56
+    Date 420.24
+    Strawberry 478.29
+    Cactus_Pear 799.25
+    Pear 517.17
+    Cranberry 1071.16
+    Brussels_Sprouts 681.27
+    Turnip 545.25
+    Avocado 388.20
+    Mint 580.41
+    Clementine 778.62
+    Kale 341.65
+    Goji_Berry 798.56
+    Peach 253.24
+    Rutabaga 600.63
+    Persimmon 430.59
+    Kohlrabi 775.59
+    Peas 305.33
+    Parsley 763.04
+    Garlic 593.84
+    Cilantro 750.82
+    Cauliflower 530.45
+    Grapes 380.04
+    Squash_Blossom 479.57
+    Tomato 519.53
+    Pomegranate 992.19
+    Orange 260.43
+    Endive 313.78
+    Jackfruit 501.29
+    Bok_Choy 611.15
+    Mango 611.78
+    Plum 421.35
+    Salsify 700.26
+    Basil 717.57
+    Banana 783.61
+    Blackberry 251.47
+    Okra 820.45
+    Collard_Greens 425.31
+    Lettuce 554.64
+    Jicama 533.39
+    Apple 997.97
+    Honeydew 1002.66
+    Onion 328.90
+    Fig 666.20
+    Spinach 448.21
+    Plantain 461.40
+    Sale 49661.38
+    Honeydew 1111.14
+    Brussels_Sprouts 851.79
+    Asparagus 650.37
+    Oregano 562.83
+    Zucchini 628.32
+    Cilantro 619.48
+    Parsley 331.72
+    Lettuce 282.59
+    Pear 145.20
+    Pumpkin 484.28
+    Ginger 359.99
+    Thyme 301.36
+    Clementine 836.25
+    Turnip 362.81
+    Jicama 538.84
+    Cantaloupe 962.85
+    Cherry 429.50
+    Kohlrabi 540.92
+    Strawberry 817.57
+    Butternut_Squash 150.45
+    Watercress 692.32
+    Kiwano 534.80
+    Dragon_Fruit 758.09
+    Persimmon 802.37
+    Plum 355.44
+    Rosemary 772.68
+    Mint 396.17
+    Spinach 326.55
+    Chard 332.60
+    Goji_Berry 334.87
+    Collard_Greens 409.64
+    Kiwi 400.28
+    Plantain 474.68
+    Pineapple 289.79
+    Apple 487.65
+    Celery 673.94
+    Radish 442.96
+    Grapefruit 594.15
+    Blueberry 601.16
+    Orange 365.47
+    Eggplant 514.89
+    Onion 529.36
+    Okra 393.80
+    Green_Beans 330.72
+    Garlic 232.51
+    Coconut 888.58
+    Guava 644.98
+    Lemon 250.58
+    Papaya 213.89
+    Nectarine 550.82
+    Salsify 62.04
+    Avocado 388.45
+    Currant 426.82
+    Potato 1189.66
+    Apricot 309.75
+    Sweet_Potato 989.60
+    Peas 448.13
+    Bok_Choy 698.08
+    Endive 96.10
+    Artichoke 668.72
+    Date 511.86
+    Lime 808.19
+    Basil 567.71
+    Banana 280.60
+    Mango 603.09
+    Cauliflower 310.49
+    Grapes 527.49
+    Carrot 733.30
+    Watermelon 585.95
+    Raspberry 469.58
+    Kale 727.99
+    Broccoli 265.96
+    Dill 771.60
+    Peach 503.03
+    Cranberry 1220.56
+    Squash_Blossom 711.99
+    Blackberry 844.78
+    Sage 437.19
+    Fig 514.05
+    Tomato 569.62
+    Passion_Fruit 374.47
+    Parsnip 527.37
+    Rhubarb 334.77
+    Beet 341.86
+    Rutabaga 218.36
+    Jackfruit 226.58
+    Starfruit 580.38
+    Yam 467.88
+    Pomegranate 939.73
+    Cabbage 417.68
+    Bell_Pepper 684.62
+    Acorn_Squash 513.09
+    Cactus_Pear 534.76
+    Cucumber 693.45
+    Boujdour 50830.82
+    Carrot 271.27
+    Papaya 476.58
+    Oregano 727.03
+    Asparagus 643.91
+    Dill 880.59
+    Thyme 710.42
+    Peas 1007.91
+    Brussels_Sprouts 563.21
+    Mango 297.46
+    Pear 572.96
+    Butternut_Squash 604.96
+    Strawberry 349.88
+    Fig 345.18
+    Passion_Fruit 92.36
+    Rutabaga 1001.75
+    Jackfruit 707.90
+    Pomegranate 941.17
+    Banana 660.91
+    Celery 330.36
+    Cucumber 824.22
+    Chard 743.00
+    Goji_Berry 539.18
+    Apple 618.99
+    Currant 472.84
+    Radish 478.22
+    Grapes 629.18
+    Blackberry 590.02
+    Parsley 814.16
+    Cilantro 501.21
+    Cherry 671.65
+    Pineapple 739.99
+    Cauliflower 627.08
+    Turnip 606.70
+    Cranberry 712.27
+    Pumpkin 685.02
+    Okra 158.47
+    Endive 759.75
+    Yam 317.95
+    Bell_Pepper 164.35
+    Mint 327.66
+    Broccoli 505.39
+    Spinach 217.91
+    Rhubarb 772.99
+    Kale 158.32
+    Blueberry 158.12
+    Sage 380.46
+    Potato 564.82
+    Honeydew 888.67
+    Peach 572.85
+    Plantain 169.25
+    Garlic 647.09
+    Cantaloupe 1019.89
+    Lemon 453.23
+    Dragon_Fruit 418.84
+    Beet 490.71
+    Parsnip 198.66
+    Lettuce 760.45
+    Kohlrabi 580.21
+    Lime 634.06
+    Bok_Choy 388.21
+    Plum 512.94
+    Guava 421.43
+    Artichoke 989.56
+    Acorn_Squash 545.59
+    Coconut 897.29
+    Avocado 528.69
+    Date 446.44
+    Kiwi 116.59
+    Tomato 325.38
+    Cabbage 600.86
+    Green_Beans 476.50
+    Apricot 479.46
+    Nectarine 576.11
+    Salsify 828.95
+    Orange 479.74
+    Jicama 409.30
+    Collard_Greens 579.39
+    Basil 229.73
+    Watercress 542.45
+    Watermelon 183.17
+    Grapefruit 420.55
+    Zucchini 613.00
+    Cactus_Pear 497.35
+    Onion 172.63
+    Kiwano 468.41
+    Rosemary 797.05
+    Raspberry 507.75
+    Ginger 619.50
+    Sweet_Potato 319.85
+    Starfruit 460.18
+    Clementine 611.80
+    Squash_Blossom 529.62
+    Persimmon 590.02
+    Eggplant 905.69
+    Youssoufia 50898.89
+    Bell_Pepper 528.49
+    Grapes 525.76
+    Jackfruit 350.16
+    Strawberry 369.84
+    Date 748.69
+    Mint 574.19
+    Mango 1100.27
+    Salsify 433.29
+    Asparagus 380.40
+    Papaya 477.86
+    Eggplant 659.43
+    Cucumber 376.50
+    Carrot 470.02
+    Parsnip 677.52
+    Peas 659.47
+    Spinach 574.75
+    Turnip 722.97
+    Pineapple 452.17
+    Watercress 195.17
+    Rhubarb 374.17
+    Blueberry 232.86
+    Clementine 533.15
+    Orange 358.18
+    Potato 649.15
+    Kohlrabi 433.30
+    Collard_Greens 536.72
+    Goji_Berry 545.49
+    Artichoke 955.74
+    Kiwano 404.56
+    Beet 255.24
+    Ginger 765.26
+    Banana 601.58
+    Guava 389.76
+    Pumpkin 598.97
+    Okra 412.41
+    Thyme 327.53
+    Plantain 615.80
+    Cauliflower 423.75
+    Pomegranate 1314.22
+    Broccoli 617.63
+    Coconut 1084.52
+    Plum 457.61
+    Apricot 377.09
+    Dragon_Fruit 750.74
+    Passion_Fruit 494.13
+    Celery 822.53
+    Squash_Blossom 652.81
+    Chard 252.64
+    Peach 343.59
+    Persimmon 320.20
+    Sage 330.24
+    Garlic 615.90
+    Zucchini 246.41
+    Lemon 519.50
+    Oregano 306.45
+    Green_Beans 627.12
+    Blackberry 323.15
+    Brussels_Sprouts 317.65
+    Starfruit 679.84
+    Onion 696.99
+    Sweet_Potato 428.02
+    Watermelon 515.98
+    Rosemary 475.42
+    Butternut_Squash 761.09
+    Parsley 472.53
+    Lime 463.93
+    Endive 510.76
+    Honeydew 1276.77
+    Cabbage 379.67
+    Kale 667.98
+    Fig 547.27
+    Radish 516.03
+    Yam 463.25
+    Cherry 531.53
+    Kiwi 350.48
+    Rutabaga 313.42
+    Cranberry 1050.54
+    Tomato 630.59
+    Dill 476.60
+    Lettuce 661.87
+    Raspberry 503.53
+    Currant 457.49
+    Avocado 546.95
+    Cactus_Pear 548.18
+    Grapefruit 575.84
+    Nectarine 531.00
+    Basil 442.00
+    Cantaloupe 896.66
+    Jicama 600.46
+    Cilantro 487.23
+    Pear 502.64
+    Apple 291.48
+    Acorn_Squash 655.50
+    Bok_Choy 524.67
+    Agadir 50896.19
+    Goji_Berry 824.68
+    Pineapple 497.30
+    Clementine 769.61
+    Zucchini 670.96
+    Jicama 436.25
+    Apple 385.07
+    Passion_Fruit 676.31
+    Banana 664.15
+    Rutabaga 634.38
+    Honeydew 841.65
+    Watercress 682.97
+    Squash_Blossom 278.40
+    Basil 255.96
+    Tomato 951.74
+    Dragon_Fruit 771.83
+    Blackberry 628.58
+    Cilantro 299.82
+    Persimmon 1191.64
+    Grapefruit 440.75
+    Turnip 541.07
+    Cactus_Pear 535.63
+    Peas 267.08
+    Chard 548.70
+    Green_Beans 411.51
+    Garlic 281.44
+    Bok_Choy 954.29
+    Parsley 397.34
+    Celery 667.59
+    Kiwano 672.12
+    Carrot 484.82
+    Kiwi 912.74
+    Jackfruit 372.34
+    Collard_Greens 433.45
+    Onion 903.77
+    Potato 568.62
+    Asparagus 485.03
+    Pumpkin 107.29
+    Rosemary 442.36
+    Cantaloupe 997.13
+    Starfruit 562.87
+    Acorn_Squash 365.85
+    Peach 349.14
+    Cranberry 1164.96
+    Salsify 529.77
+    Artichoke 1401.45
+    Watermelon 417.98
+    Date 322.69
+    Kale 241.40
+    Radish 153.60
+    Lemon 190.91
+    Kohlrabi 518.55
+    Currant 876.52
+    Beet 347.43
+    Endive 63.49
+    Strawberry 565.84
+    Oregano 711.51
+    Avocado 79.69
+    Spinach 672.05
+    Papaya 326.29
+    Ginger 645.44
+    Blueberry 418.89
+    Nectarine 370.70
+    Eggplant 516.95
+    Dill 425.25
+    Cabbage 397.03
+    Sweet_Potato 682.19
+    Sage 435.47
+    Apricot 365.43
+    Coconut 1651.66
+    Cauliflower 210.27
+    Mango 279.98
+    Plantain 295.01
+    Butternut_Squash 278.57
+    Fig 239.01
+    Mint 420.22
+    Broccoli 452.55
+    Yam 374.65
+    Thyme 372.25
+    Okra 416.08
+    Lettuce 709.92
+    Brussels_Sprouts 628.34
+    Bell_Pepper 336.46
+    Pomegranate 1222.36
+    Plum 488.94
+    Guava 640.10
+    Cherry 388.86
+    Grapes 333.71
+    Pear 576.22
+    Rhubarb 653.94
+    Cucumber 925.28
+    Parsnip 422.03
+    Orange 318.44
+    Lime 606.17
+    Raspberry 649.46
+    Berkane 51264.30
+    Green_Beans 362.94
+    Carrot 742.80
+    Lemon 1081.56
+    Salsify 369.19
+    Brussels_Sprouts 338.76
+    Cucumber 364.25
+    Kiwano 402.14
+    Cantaloupe 861.21
+    Tomato 585.46
+    Pumpkin 337.09
+    Honeydew 816.10
+    Passion_Fruit 351.43
+    Papaya 561.87
+    Zucchini 573.40
+    Cherry 715.09
+    Turnip 394.87
+    Goji_Berry 238.58
+    Blueberry 774.31
+    Okra 277.36
+    Guava 593.43
+    Ginger 840.00
+    Endive 592.69
+    Sweet_Potato 636.97
+    Jackfruit 509.39
+    Coconut 1174.84
+    Yam 434.20
+    Fig 844.55
+    Peas 1084.40
+    Jicama 881.45
+    Pomegranate 814.41
+    Cilantro 492.16
+    Rosemary 264.51
+    Broccoli 475.23
+    Peach 376.71
+    Starfruit 461.30
+    Thyme 540.83
+    Banana 757.86
+    Asparagus 637.55
+    Cactus_Pear 669.57
+    Bok_Choy 288.63
+    Pear 436.16
+    Basil 417.45
+    Orange 332.18
+    Potato 363.53
+    Nectarine 265.55
+    Currant 816.22
+    Plum 483.03
+    Dragon_Fruit 531.49
+    Watermelon 599.25
+    Mango 285.17
+    Pineapple 776.86
+    Artichoke 977.25
+    Rutabaga 763.68
+    Collard_Greens 674.76
+    Oregano 587.91
+    Eggplant 345.36
+    Butternut_Squash 251.12
+    Parsley 779.79
+    Clementine 295.80
+    Celery 106.70
+    Strawberry 403.96
+    Bell_Pepper 563.42
+    Cauliflower 421.00
+    Lettuce 390.17
+    Blackberry 656.36
+    Squash_Blossom 312.22
+    Spinach 348.02
+    Beet 668.28
+    Kiwi 288.36
+    Kohlrabi 672.14
+    Acorn_Squash 724.60
+    Parsnip 605.11
+    Garlic 770.88
+    Radish 471.69
+    Mint 229.39
+    Kale 556.26
+    Chard 534.87
+    Rhubarb 980.55
+    Sage 536.37
+    Avocado 438.82
+    Dill 558.47
+    Date 305.05
+    Onion 592.55
+    Grapefruit 634.96
+    Cranberry 980.25
+    Cabbage 638.65
+    Lime 561.84
+    Plantain 507.82
+    Watercress 247.96
+    Apple 124.14
+    Raspberry 692.41
+    Persimmon 615.63
+    Apricot 290.52
+    Grapes 333.23
+    Jorf_El_Melha 51134.59
+    Apple 320.09
+    Carrot 361.15
+    Cherry 600.44
+    Ginger 325.78
+    Cactus_Pear 421.09
+    Papaya 456.04
+    Peas 699.03
+    Honeydew 1273.07
+    Green_Beans 488.26
+    Pear 477.33
+    Clementine 501.16
+    Rhubarb 411.71
+    Celery 233.70
+    Kiwi 617.39
+    Rosemary 807.99
+    Kohlrabi 617.69
+    Persimmon 653.27
+    Onion 531.66
+    Rutabaga 309.35
+    Oregano 310.98
+    Pumpkin 499.56
+    Asparagus 609.58
+    Broccoli 354.93
+    Chard 391.21
+    Squash_Blossom 201.02
+    Grapes 431.29
+    Pomegranate 857.13
+    Collard_Greens 305.78
+    Date 371.81
+    Cabbage 632.02
+    Plum 415.17
+    Fig 584.15
+    Goji_Berry 487.99
+    Spinach 484.32
+    Radish 623.13
+    Raspberry 351.48
+    Turnip 614.65
+    Cucumber 546.59
+    Garlic 502.19
+    Thyme 648.15
+    Dill 371.90
+    Lettuce 273.24
+    Starfruit 563.65
+    Dragon_Fruit 433.84
+    Mint 244.37
+    Orange 815.27
+    Cilantro 657.75
+    Endive 536.94
+    Currant 598.95
+    Potato 256.19
+    Plantain 700.11
+    Beet 368.97
+    Pineapple 340.33
+    Passion_Fruit 358.26
+    Blackberry 525.79
+    Lemon 357.08
+    Salsify 429.05
+    Watermelon 961.55
+    Blueberry 427.69
+    Coconut 1519.90
+    Brussels_Sprouts 743.13
+    Parsley 571.44
+    Guava 400.89
+    Kiwano 531.49
+    Cauliflower 623.75
+    Jicama 398.45
+    Cranberry 780.99
+    Bok_Choy 391.72
+    Basil 427.50
+    Zucchini 400.14
+    Butternut_Squash 599.22
+    Apricot 436.41
+    Watercress 711.76
+    Acorn_Squash 350.58
+    Jackfruit 678.27
+    Mango 854.14
+    Bell_Pepper 448.49
+    Parsnip 404.48
+    Nectarine 821.84
+    Grapefruit 314.20
+    Artichoke 1253.42
+    Tomato 522.46
+    Strawberry 571.67
+    Lime 836.95
+    Sweet_Potato 629.17
+    Cantaloupe 863.84
+    Avocado 447.66
+    Eggplant 582.05
+    Kale 801.49
+    Peach 394.09
+    Yam 509.49
+    Sage 502.61
+    Banana 624.04
+    Okra 636.60
+    Safi 48807.32
+    Currant 673.99
+    Pear 254.67
+    Blueberry 659.72
+    Pumpkin 703.57
+    Potato 723.16
+    Yam 321.55
+    Artichoke 765.20
+    Thyme 335.08
+    Honeydew 854.53
+    Nectarine 653.38
+    Garlic 266.21
+    Raspberry 180.35
+    Jicama 544.70
+    Cilantro 379.98
+    Bok_Choy 964.13
+    Goji_Berry 553.09
+    Onion 478.30
+    Brussels_Sprouts 282.13
+    Jackfruit 571.93
+    Kiwano 388.83
+    Green_Beans 249.56
+    Pomegranate 931.57
+    Cherry 169.55
+    Guava 392.61
+    Rosemary 336.53
+    Cucumber 857.62
+    Endive 406.88
+    Plantain 651.94
+    Apple 430.81
+    Carrot 495.44
+    Cactus_Pear 547.07
+    Parsley 265.75
+    Grapes 278.80
+    Cantaloupe 1678.16
+    Kohlrabi 471.34
+    Starfruit 384.00
+    Bell_Pepper 412.90
+    Squash_Blossom 581.24
+    Chard 462.80
+    Date 938.35
+    Mango 662.47
+    Peas 461.71
+    Watermelon 839.51
+    Orange 256.24
+    Basil 717.28
+    Banana 479.94
+    Rutabaga 386.59
+    Butternut_Squash 349.26
+    Lemon 624.68
+    Plum 739.51
+    Sweet_Potato 579.60
+    Cranberry 710.19
+    Peach 317.30
+    Coconut 917.82
+    Avocado 531.80
+    Asparagus 360.02
+    Lime 273.72
+    Radish 320.36
+    Apricot 567.39
+    Dragon_Fruit 627.50
+    Grapefruit 462.83
+    Persimmon 501.40
+    Rhubarb 260.95
+    Spinach 545.75
+    Papaya 527.95
+    Tomato 294.39
+    Collard_Greens 575.99
+    Blackberry 546.68
+    Sage 410.20
+    Turnip 321.78
+    Okra 518.59
+    Watercress 594.18
+    Beet 471.83
+    Broccoli 441.03
+    Kale 246.87
+    Ginger 465.51
+    Cauliflower 815.93
+    Pineapple 416.81
+    Oregano 661.63
+    Fig 487.12
+    Cabbage 981.50
+    Celery 520.58
+    Mint 432.10
+    Parsnip 423.97
+    Kiwi 634.42
+    Dill 758.58
+    Eggplant 432.79
+    Clementine 266.07
+    Lettuce 336.11
+    Acorn_Squash 551.11
+    Strawberry 294.07
+    Salsify 635.76
+    Zucchini 235.93
+    Passion_Fruit 516.60
+    Smara 50188.19
+    Raspberry 633.68
+    Plum 607.50
+    Date 271.85
+    Artichoke 1009.76
+    Okra 627.04
+    Sweet_Potato 356.41
+    Eggplant 518.41
+    Spinach 278.39
+    Grapes 317.83
+    Fig 605.12
+    Plantain 688.56
+    Basil 329.18
+    Guava 341.81
+    Kiwano 696.34
+    Asparagus 486.35
+    Parsley 206.66
+    Pineapple 520.20
+    Mango 496.58
+    Nectarine 404.08
+    Dill 560.36
+    Apricot 337.16
+    Rosemary 561.88
+    Cherry 581.56
+    Tomato 352.18
+    Cactus_Pear 419.67
+    Dragon_Fruit 362.26
+    Honeydew 974.33
+    Currant 790.22
+    Collard_Greens 427.26
+    Peas 596.57
+    Bell_Pepper 699.65
+    Cantaloupe 1175.47
+    Rhubarb 392.64
+    Salsify 348.87
+    Butternut_Squash 630.83
+    Passion_Fruit 288.27
+    Pear 499.69
+    Cabbage 558.65
+    Celery 451.94
+    Brussels_Sprouts 358.21
+    Potato 402.88
+    Kale 665.35
+    Radish 131.56
+    Pumpkin 403.95
+    Peach 1012.14
+    Goji_Berry 535.14
+    Kohlrabi 575.38
+    Banana 692.80
+    Cucumber 527.77
+    Coconut 1061.27
+    Avocado 705.18
+    Squash_Blossom 992.47
+    Zucchini 732.55
+    Blueberry 662.28
+    Grapefruit 394.99
+    Yam 573.44
+    Lettuce 791.29
+    Persimmon 648.07
+    Onion 556.30
+    Broccoli 479.51
+    Garlic 653.55
+    Green_Beans 369.35
+    Cilantro 413.15
+    Jackfruit 598.55
+    Cranberry 661.58
+    Bok_Choy 410.38
+    Kiwi 465.30
+    Beet 676.76
+    Turnip 416.51
+    Blackberry 292.81
+    Oregano 310.16
+    Lime 566.47
+    Cauliflower 617.03
+    Pomegranate 700.40
+    Papaya 599.88
+    Carrot 369.47
+    Chard 670.91
+    Ginger 354.65
+    Starfruit 632.28
+    Lemon 529.58
+    Watermelon 619.16
+    Sage 335.52
+    Clementine 643.29
+    Apple 323.97
+    Thyme 509.11
+    Endive 364.41
+    Acorn_Squash 498.88
+    Watercress 465.98
+    Strawberry 348.45
+    Orange 474.39
+    Jicama 567.80
+    Rutabaga 433.43
+    Parsnip 364.58
+    Mint 622.71
+    Akhfenir 54137.18
+    Tomato 875.41
+    Peas 896.32
+    Plantain 410.21
+    Clementine 663.65
+    Spinach 482.89
+    Squash_Blossom 499.83
+    Beet 410.21
+    Pineapple 353.98
+    Rutabaga 679.28
+    Acorn_Squash 211.33
+    Parsley 385.42
+    Radish 600.09
+    Lettuce 477.87
+    Strawberry 1184.42
+    Broccoli 416.38
+    Apricot 578.19
+    Oregano 797.52
+    Bell_Pepper 459.75
+    Banana 883.90
+    Starfruit 1092.68
+    Kiwi 490.44
+    Dill 592.79
+    Potato 505.73
+    Guava 675.65
+    Avocado 415.51
+    Bok_Choy 542.25
+    Apple 506.39
+    Endive 327.73
+    Raspberry 362.93
+    Plum 196.81
+    Pear 365.91
+    Dragon_Fruit 797.88
+    Cactus_Pear 578.66
+    Thyme 642.92
+    Salsify 397.27
+    Passion_Fruit 437.00
+    Nectarine 436.08
+    Cantaloupe 1348.74
+    Parsnip 625.75
+    Lemon 298.33
+    Ginger 558.87
+    Celery 750.89
+    Cranberry 1147.68
+    Orange 123.55
+    Lime 562.09
+    Cucumber 806.58
+    Cherry 479.84
+    Fig 403.59
+    Basil 499.68
+    Sweet_Potato 374.83
+    Rhubarb 800.55
+    Chard 345.84
+    Pumpkin 479.96
+    Okra 371.90
+    Brussels_Sprouts 881.23
+    Rosemary 412.46
+    Kohlrabi 727.09
+    Mint 532.56
+    Yam 144.57
+    Jicama 891.17
+    Onion 655.04
+    Jackfruit 532.37
+    Cauliflower 316.12
+    Honeydew 1030.17
+    Mango 554.74
+    Watermelon 276.68
+    Blackberry 411.91
+    Watercress 387.61
+    Kale 650.48
+    Peach 594.05
+    Date 753.02
+    Cilantro 508.21
+    Cabbage 532.64
+    Goji_Berry 403.94
+    Green_Beans 321.40
+    Artichoke 1188.65
+    Papaya 810.57
+    Butternut_Squash 475.49
+    Asparagus 365.30
+    Eggplant 425.45
+    Sage 430.30
+    Pomegranate 814.15
+    Garlic 632.23
+    Grapefruit 691.92
+    Grapes 803.60
+    Turnip 642.16
+    Zucchini 267.54
+    Kiwano 537.48
+    Currant 927.34
+    Persimmon 481.37
+    Coconut 1199.69
+    Collard_Greens 211.75
+    Blueberry 528.75
+    Carrot 576.03
+    Ben_guerir 47154.53
+    Ginger 579.53
+    Artichoke 866.64
+    Starfruit 250.14
+    Chard 695.27
+    Collard_Greens 532.52
+    Cantaloupe 688.72
+    Apricot 585.68
+    Sweet_Potato 476.45
+    Raspberry 403.92
+    Watercress 360.83
+    Apple 735.32
+    Bell_Pepper 498.93
+    Peach 428.52
+    Sage 311.57
+    Cabbage 298.13
+    Strawberry 571.58
+    Cranberry 1213.75
+    Cauliflower 519.98
+    Banana 410.26
+    Butternut_Squash 208.41
+    Grapefruit 467.60
+    Turnip 197.58
+    Cactus_Pear 359.31
+    Okra 454.90
+    Jackfruit 553.25
+    Fig 256.33
+    Kale 243.48
+    Clementine 514.03
+    Plum 579.33
+    Green_Beans 576.72
+    Guava 483.06
+    Dill 302.02
+    Mint 921.30
+    Bok_Choy 466.51
+    Grapes 547.27
+    Passion_Fruit 278.43
+    Persimmon 662.33
+    Orange 294.11
+    Oregano 926.57
+    Blueberry 351.86
+    Beet 342.26
+    Lemon 268.94
+    Rutabaga 328.63
+    Jicama 301.00
+    Lime 393.00
+    Parsnip 530.07
+    Zucchini 391.93
+    Lettuce 426.48
+    Date 583.96
+    Currant 357.04
+    Carrot 920.14
+    Papaya 844.31
+    Watermelon 295.48
+    Broccoli 357.40
+    Pumpkin 345.21
+    Garlic 372.23
+    Goji_Berry 809.08
+    Cherry 347.03
+    Basil 421.50
+    Radish 777.18
+    Tomato 765.00
+    Parsley 812.69
+    Pear 325.89
+    Plantain 760.75
+    Peas 506.67
+    Yam 339.21
+    Kohlrabi 522.14
+    Onion 327.20
+    Acorn_Squash 563.17
+    Endive 412.64
+    Avocado 343.83
+    Pomegranate 700.94
+    Kiwano 546.10
+    Celery 620.01
+    Thyme 602.48
+    Brussels_Sprouts 648.38
+    Coconut 896.84
+    Spinach 422.69
+    Nectarine 313.32
+    Cucumber 366.88
+    Salsify 492.11
+    Blackberry 571.65
+    Rhubarb 315.81
+    Pineapple 419.61
+    Dragon_Fruit 723.76
+    Cilantro 499.29
+    Potato 355.00
+    Asparagus 442.57
+    Eggplant 259.76
+    Kiwi 224.30
+    Mango 883.23
+    Squash_Blossom 159.73
+    Honeydew 1000.17
+    Rosemary 525.70
+    Meknes 52043.00
+    Blackberry 444.47
+    Cranberry 1021.71
+    Eggplant 488.70
+    Lemon 250.97
+    Potato 372.96
+    Butternut_Squash 699.07
+    Orange 528.25
+    Currant 670.18
+    Dill 346.70
+    Cabbage 105.22
+    Kale 778.08
+    Guava 320.41
+    Apple 521.73
+    Thyme 917.93
+    Mint 641.24
+    Peas 606.79
+    Ginger 700.13
+    Tomato 493.88
+    Radish 284.99
+    Oregano 491.68
+    Green_Beans 409.71
+    Pomegranate 792.59
+    Pear 582.62
+    Broccoli 590.40
+    Banana 469.53
+    Honeydew 777.19
+    Sage 496.71
+    Peach 790.29
+    Rhubarb 400.23
+    Lettuce 753.75
+    Bell_Pepper 536.54
+    Papaya 422.92
+    Celery 752.03
+    Cactus_Pear 663.54
+    Kiwano 395.54
+    Watermelon 437.15
+    Rosemary 510.27
+    Lime 381.97
+    Clementine 550.72
+    Raspberry 346.42
+    Turnip 680.36
+    Okra 488.22
+    Coconut 747.65
+    Onion 418.96
+    Plantain 763.33
+    Yam 513.14
+    Asparagus 485.33
+    Garlic 714.23
+    Plum 395.63
+    Apricot 592.49
+    Watercress 700.75
+    Rutabaga 558.21
+    Jackfruit 960.15
+    Pumpkin 559.61
+    Endive 131.11
+    Parsley 678.19
+    Cauliflower 402.98
+    Grapes 412.31
+    Spinach 497.32
+    Parsnip 856.90
+    Kohlrabi 266.47
+    Jicama 417.30
+    Bok_Choy 169.17
+    Mango 605.92
+    Blueberry 614.71
+    Nectarine 607.23
+    Cantaloupe 494.34
+    Starfruit 879.89
+    Cucumber 429.80
+    Carrot 688.62
+    Passion_Fruit 485.37
+    Fig 622.57
+    Salsify 507.94
+    Brussels_Sprouts 488.48
+    Cilantro 420.59
+    Kiwi 560.80
+    Collard_Greens 602.21
+    Cherry 827.74
+    Basil 141.11
+    Chard 477.28
+    Beet 553.23
+    Zucchini 302.06
+    Dragon_Fruit 826.57
+    Goji_Berry 531.12
+    Date 576.82
+    Avocado 782.78
+    Persimmon 522.81
+    Artichoke 1515.96
+    Squash_Blossom 140.02
+    Sweet_Potato 646.27
+    Grapefruit 491.21
+    Strawberry 641.43
+    Acorn_Squash 607.85
+    Pineapple 295.25
+    Beni_Mellal 47662.59
+    Rutabaga 361.80
+    Mango 640.35
+    Cherry 271.28
+    Blackberry 375.80
+    Ginger 343.11
+    Kohlrabi 610.00
+    Papaya 708.89
+    Eggplant 525.12
+    Sage 477.51
+    Oregano 145.58
+    Acorn_Squash 820.37
+    Pumpkin 668.57
+    Pineapple 427.88
+    Apricot 413.58
+    Celery 607.31
+    Broccoli 774.10
+    Basil 439.52
+    Currant 741.48
+    Plum 420.66
+    Apple 206.17
+    Cactus_Pear 385.33
+    Sweet_Potato 609.16
+    Tomato 642.00
+    Mint 205.22
+    Parsnip 299.88
+    Persimmon 404.00
+    Passion_Fruit 786.65
+    Zucchini 591.37
+    Orange 384.56
+    Rhubarb 698.91
+    Rosemary 446.41
+    Artichoke 701.08
+    Kiwi 367.68
+    Pomegranate 451.21
+    Date 545.90
+    Asparagus 643.88
+    Salsify 343.74
+    Cranberry 837.00
+    Peach 574.78
+    Lemon 342.22
+    Dragon_Fruit 643.81
+    Jicama 195.82
+    Garlic 417.32
+    Nectarine 686.95
+    Cilantro 266.75
+    Watermelon 478.25
+    Strawberry 443.74
+    Dill 447.43
+    Plantain 283.42
+    Honeydew 1329.01
+    Potato 598.36
+    Endive 432.23
+    Collard_Greens 858.59
+    Beet 859.93
+    Chard 189.18
+    Butternut_Squash 389.20
+    Green_Beans 533.95
+    Fig 275.57
+    Peas 366.69
+    Starfruit 266.07
+    Parsley 414.95
+    Thyme 598.54
+    Kale 557.24
+    Carrot 316.31
+    Cauliflower 562.04
+    Guava 440.38
+    Cantaloupe 994.65
+    Lettuce 409.49
+    Lime 108.21
+    Bell_Pepper 501.98
+    Brussels_Sprouts 494.24
+    Squash_Blossom 472.65
+    Cucumber 520.11
+    Jackfruit 670.38
+    Banana 370.02
+    Goji_Berry 599.53
+    Onion 696.61
+    Raspberry 489.09
+    Avocado 540.56
+    Spinach 213.25
+    Clementine 378.13
+    Okra 412.42
+    Yam 548.06
+    Cabbage 552.85
+    Radish 221.07
+    Pear 521.93
+    Watercress 444.50
+    Grapefruit 478.46
+    Coconut 1427.01
+    Bok_Choy 433.68
+    Turnip 610.58
+    Kiwano 450.59
+    Grapes 448.79
+    Blueberry 561.96
+    Kenitra 50362.18
+    Ginger 665.84
+    Celery 332.36
+    Green_Beans 490.26
+    Parsley 771.34
+    Mint 635.69
+    Raspberry 381.70
+    Cilantro 380.71
+    Squash_Blossom 548.23
+    Garlic 547.66
+    Kiwano 388.91
+    Avocado 820.54
+    Lettuce 316.19
+    Turnip 718.95
+    Goji_Berry 607.64
+    Chard 83.08
+    Blueberry 470.82
+    Pineapple 686.18
+    Beet 729.83
+    Watercress 325.98
+    Spinach 455.75
+    Rutabaga 515.46
+    Oregano 131.94
+    Honeydew 1696.51
+    Kohlrabi 680.91
+    Tomato 928.63
+    Cauliflower 174.56
+    Clementine 238.51
+    Kale 592.88
+    Yam 365.08
+    Artichoke 1222.41
+    Dragon_Fruit 183.24
+    Fig 476.76
+    Cucumber 470.74
+    Passion_Fruit 543.43
+    Cactus_Pear 603.98
+    Parsnip 746.96
+    Bok_Choy 482.59
+    Guava 339.41
+    Sweet_Potato 185.52
+    Broccoli 262.76
+    Lime 470.71
+    Salsify 775.02
+    Strawberry 710.92
+    Date 379.78
+    Jackfruit 737.26
+    Starfruit 703.51
+    Watermelon 523.88
+    Pumpkin 376.03
+    Butternut_Squash 638.51
+    Apple 920.26
+    Zucchini 231.24
+    Okra 524.73
+    Currant 462.04
+    Coconut 1276.82
+    Papaya 395.72
+    Bell_Pepper 356.52
+    Cherry 561.28
+    Onion 634.72
+    Acorn_Squash 455.12
+    Brussels_Sprouts 638.35
+    Apricot 484.22
+    Orange 422.20
+    Cantaloupe 945.61
+    Plum 617.03
+    Plantain 632.12
+    Nectarine 466.15
+    Cabbage 334.75
+    Sage 342.04
+    Grapefruit 623.70
+    Banana 572.71
+    Mango 591.96
+    Persimmon 491.91
+    Rosemary 279.46
+    Asparagus 451.78
+    Pear 147.56
+    Jicama 648.21
+    Dill 453.72
+    Grapes 458.36
+    Pomegranate 785.98
+    Radish 431.18
+    Carrot 440.01
+    Lemon 553.98
+    Collard_Greens 216.66
+    Peas 553.39
+    Blackberry 361.00
+    Basil 391.71
+    Rhubarb 772.87
+    Potato 529.58
+    Endive 878.32
+    Thyme 376.12
+    Cranberry 695.19
+    Eggplant 665.72
+    Kiwi 561.32
+    Peach 213.30
+    Tinghir 47935.50
+    Basil 757.42
+    Rosemary 668.90
+    Garlic 243.11
+    Collard_Greens 558.86
+    Squash_Blossom 325.52
+    Brussels_Sprouts 272.17
+    Cilantro 277.72
+    Onion 516.94
+    Oregano 127.57
+    Watercress 279.61
+    Pumpkin 562.79
+    Dragon_Fruit 415.98
+    Turnip 539.08
+    Raspberry 878.24
+    Cherry 443.57
+    Mango 607.88
+    Lemon 663.06
+    Coconut 1193.10
+    Clementine 691.03
+    Parsley 431.87
+    Beet 748.58
+    Jackfruit 417.04
+    Guava 481.90
+    Cucumber 239.54
+    Orange 782.23
+    Parsnip 454.91
+    Pineapple 355.04
+    Bok_Choy 577.48
+    Rhubarb 431.64
+    Bell_Pepper 171.36
+    Kohlrabi 528.09
+    Thyme 682.45
+    Acorn_Squash 481.71
+    Salsify 431.89
+    Peach 796.84
+    Spinach 234.49
+    Banana 864.39
+    Blackberry 438.14
+    Currant 195.76
+    Strawberry 181.78
+    Honeydew 1366.39
+    Cauliflower 480.36
+    Papaya 426.01
+    Fig 541.78
+    Date 608.33
+    Dill 278.13
+    Sweet_Potato 234.42
+    Starfruit 430.01
+    Kale 440.29
+    Persimmon 736.56
+    Green_Beans 421.00
+    Cactus_Pear 428.42
+    Grapefruit 679.89
+    Apricot 454.15
+    Potato 824.32
+    Rutabaga 721.80
+    Pear 194.46
+    Passion_Fruit 285.90
+    Lime 344.21
+    Celery 642.51
+    Lettuce 368.51
+    Cranberry 1085.03
+    Avocado 513.59
+    Goji_Berry 423.17
+    Grapes 292.01
+    Watermelon 627.95
+    Radish 184.19
+    Pomegranate 720.59
+    Broccoli 493.88
+    Kiwi 456.04
+    Artichoke 919.78
+    Zucchini 492.25
+    Plum 734.58
+    Cantaloupe 1047.63
+    Apple 345.07
+    Carrot 289.07
+    Cabbage 638.58
+    Plantain 614.74
+    Tomato 428.16
+    Kiwano 505.53
+    Asparagus 262.39
+    Yam 685.69
+    Endive 529.48
+    Chard 623.07
+    Sage 333.86
+    Peas 372.39
+    Okra 166.64
+    Nectarine 330.30
+    Blueberry 479.70
+    Jicama 452.49
+    Eggplant 394.90
+    Butternut_Squash 560.20
+    Ginger 302.98
+    Mint 772.44
+    Sidi_Bouzid 50739.93
+    Cauliflower 345.52
+    Kohlrabi 557.78
+    Artichoke 1209.38
+    Apricot 504.90
+    Apple 370.38
+    Peas 343.46
+    Starfruit 676.23
+    Plum 711.39
+    Avocado 540.77
+    Lemon 393.82
+    Orange 963.01
+    Pear 383.99
+    Cactus_Pear 568.33
+    Oregano 631.90
+    Beet 807.21
+    Sage 379.87
+    Fig 355.50
+    Persimmon 371.17
+    Passion_Fruit 348.90
+    Rutabaga 141.12
+    Butternut_Squash 510.08
+    Clementine 724.06
+    Green_Beans 272.14
+    Jackfruit 420.64
+    Garlic 632.14
+    Asparagus 369.55
+    Dragon_Fruit 501.78
+    Coconut 463.76
+    Broccoli 305.70
+    Grapes 319.73
+    Parsley 588.43
+    Jicama 327.63
+    Carrot 655.36
+    Yam 530.64
+    Cantaloupe 984.43
+    Rhubarb 315.14
+    Cucumber 848.98
+    Thyme 448.01
+    Nectarine 322.90
+    Turnip 500.25
+    Bell_Pepper 828.33
+    Blackberry 698.72
+    Lettuce 1176.69
+    Blueberry 841.66
+    Potato 460.68
+    Raspberry 444.60
+    Currant 232.63
+    Sweet_Potato 488.87
+    Cilantro 926.05
+    Pumpkin 491.89
+    Grapefruit 584.25
+    Lime 339.98
+    Endive 964.64
+    Honeydew 1134.80
+    Eggplant 402.03
+    Kiwano 553.79
+    Spinach 974.53
+    Guava 248.04
+    Parsnip 440.32
+    Pineapple 432.88
+    Cherry 549.58
+    Kiwi 795.97
+    Cranberry 883.21
+    Rosemary 678.29
+    Tomato 509.07
+    Okra 420.89
+    Brussels_Sprouts 206.85
+    Date 511.72
+    Pomegranate 871.86
+    Dill 572.86
+    Mint 480.84
+    Zucchini 681.83
+    Banana 510.00
+    Watercress 575.23
+    Celery 670.60
+    Onion 453.52
+    Strawberry 576.53
+    Cabbage 229.54
+    Ginger 362.05
+    Basil 317.51
+    Kale 547.90
+    Salsify 604.95
+    Bok_Choy 383.70
+    Chard 425.39
+    Papaya 457.34
+    Goji_Berry 597.03
+    Radish 635.89
+    Collard_Greens 567.82
+    Mango 621.68
+    Acorn_Squash 513.53
+    Peach 217.82
+    Watermelon 260.19
+    Plantain 508.82
+    Squash_Blossom 228.56
+    Zagora 51392.23
+    Goji_Berry 652.47
+    Cabbage 603.91
+    Plantain 514.80
+    Okra 466.79
+    Persimmon 232.37
+    Guava 517.03
+    Brussels_Sprouts 413.10
+    Currant 656.03
+    Squash_Blossom 351.40
+    Papaya 291.05
+    Kiwano 537.06
+    Zucchini 324.82
+    Banana 687.16
+    Kale 553.69
+    Sweet_Potato 435.94
+    Lemon 637.68
+    Dragon_Fruit 476.38
+    Dill 811.49
+    Cactus_Pear 519.15
+    Turnip 489.19
+    Parsnip 298.52
+    Butternut_Squash 290.87
+    Mint 310.92
+    Plum 639.30
+    Green_Beans 458.00
+    Kiwi 461.13
+    Avocado 513.01
+    Raspberry 573.73
+    Chard 312.73
+    Kohlrabi 732.75
+    Grapefruit 640.23
+    Orange 548.01
+    Cranberry 899.55
+    Parsley 528.86
+    Passion_Fruit 478.96
+    Oregano 535.42
+    Cilantro 414.13
+    Rosemary 375.84
+    Garlic 539.49
+    Collard_Greens 446.79
+    Fig 363.05
+    Rutabaga 648.16
+    Endive 690.72
+    Potato 728.86
+    Basil 604.10
+    Watermelon 464.10
+    Apricot 737.49
+    Spinach 201.23
+    Watercress 675.05
+    Carrot 885.22
+    Yam 607.21
+    Blueberry 570.84
+    Jackfruit 526.94
+    Tomato 365.48
+    Apple 427.15
+    Peas 214.87
+    Blackberry 191.90
+    Sage 592.50
+    Onion 352.92
+    Lettuce 946.68
+    Cucumber 652.39
+    Acorn_Squash 462.08
+    Cantaloupe 875.19
+    Strawberry 873.09
+    Pomegranate 1152.51
+    Pumpkin 916.88
+    Honeydew 986.90
+    Starfruit 548.02
+    Grapes 299.68
+    Eggplant 520.62
+    Pineapple 435.80
+    Radish 461.58
+    Pear 603.80
+    Bell_Pepper 643.53
+    Jicama 517.87
+    Rhubarb 423.15
+    Mango 561.66
+    Cherry 572.76
+    Peach 495.32
+    Coconut 1188.58
+    Cauliflower 432.00
+    Broccoli 636.55
+    Thyme 287.97
+    Clementine 169.67
+    Lime 78.49
+    Salsify 638.02
+    Beet 657.45
+    Bok_Choy 614.94
+    Date 612.07
+    Celery 644.31
+    Nectarine 457.01
+    Artichoke 792.12
+    Asparagus 950.93
+    Ginger 265.07
+    Zemamra 48631.03
+    Eggplant 502.78
+    Bok_Choy 538.30
+    Papaya 612.37
+    Orange 373.22
+    Parsley 362.59
+    Kiwi 351.21
+    Salsify 304.27
+    Broccoli 446.58
+    Cucumber 378.69
+    Chard 117.46
+    Persimmon 159.37
+    Pear 618.99
+    Avocado 847.47
+    Dill 384.68
+    Cactus_Pear 470.16
+    Zucchini 453.13
+    Garlic 613.41
+    Asparagus 462.94
+    Rhubarb 384.05
+    Cherry 511.30
+    Yam 567.20
+    Cabbage 512.76
+    Grapefruit 737.41
+    Kale 297.66
+    Turnip 315.54
+    Date 914.83
+    Starfruit 563.77
+    Sweet_Potato 750.75
+    Banana 608.54
+    Green_Beans 721.72
+    Clementine 608.16
+    Lime 400.05
+    Rutabaga 633.59
+    Fig 588.80
+    Guava 709.02
+    Raspberry 903.44
+    Squash_Blossom 519.28
+    Plantain 257.61
+    Sage 414.11
+    Strawberry 312.45
+    Jackfruit 479.21
+    Cilantro 579.43
+    Cantaloupe 752.59
+    Oregano 314.33
+    Carrot 309.85
+    Lemon 436.29
+    Collard_Greens 698.61
+    Kohlrabi 441.41
+    Ginger 503.14
+    Pineapple 471.98
+    Grapes 399.46
+    Artichoke 1275.48
+    Tomato 438.57
+    Parsnip 455.25
+    Brussels_Sprouts 394.72
+    Thyme 255.33
+    Endive 185.28
+    Spinach 458.51
+    Kiwano 570.67
+    Mango 419.82
+    Cranberry 1079.72
+    Bell_Pepper 288.79
+    Peas 724.43
+    Jicama 498.84
+    Mint 770.46
+    Cauliflower 317.07
+    Pumpkin 354.47
+    Watermelon 518.59
+    Butternut_Squash 458.41
+    Okra 645.88
+    Pomegranate 786.20
+    Basil 560.68
+    Currant 473.07
+    Acorn_Squash 467.55
+    Blackberry 381.77
+    Celery 526.11
+    Apple 304.28
+    Plum 769.45
+    Radish 456.50
+    Peach 565.64
+    Nectarine 711.62
+    Rosemary 938.15
+    Beet 648.88
+    Passion_Fruit 491.32
+    Dragon_Fruit 361.66
+    Goji_Berry 306.15
+    Blueberry 446.26
+    Watercress 483.97
+    Honeydew 967.36
+    Coconut 687.25
+    Onion 941.79
+    Apricot 121.52
+    Potato 347.67
+    Lettuce 159.93
+    Fquih_Ben_Salah 51238.67
+    Yam 240.25
+    Apple 633.15
+    Kale 580.44
+    Spinach 253.79
+    Lemon 725.43
+    Cabbage 452.30
+    Dragon_Fruit 352.76
+    Cranberry 1300.34
+    Lettuce 445.40
+    Broccoli 369.68
+    Strawberry 358.00
+    Ginger 820.43
+    Garlic 692.78
+    Sweet_Potato 560.96
+    Parsley 305.66
+    Currant 596.26
+    Tomato 363.35
+    Green_Beans 352.73
+    Collard_Greens 656.94
+    Mango 584.06
+    Avocado 480.25
+    Rutabaga 381.49
+    Cucumber 634.15
+    Watercress 626.41
+    Rhubarb 656.70
+    Plantain 642.56
+    Peas 574.44
+    Orange 551.04
+    Papaya 578.75
+    Apricot 514.05
+    Date 569.08
+    Bok_Choy 547.55
+    Cactus_Pear 457.75
+    Acorn_Squash 293.03
+    Guava 384.31
+    Blueberry 358.65
+    Brussels_Sprouts 617.64
+    Nectarine 524.16
+    Rosemary 1111.04
+    Lime 673.12
+    Squash_Blossom 540.64
+    Beet 323.20
+    Goji_Berry 425.98
+    Butternut_Squash 607.18
+    Salsify 299.55
+    Pumpkin 288.99
+    Mint 546.46
+    Okra 589.48
+    Raspberry 552.05
+    Chard 660.15
+    Cherry 323.32
+    Cauliflower 499.26
+    Grapes 457.70
+    Coconut 1278.74
+    Jackfruit 525.70
+    Persimmon 869.29
+    Asparagus 86.78
+    Blackberry 268.10
+    Starfruit 658.47
+    Cilantro 512.77
+    Oregano 427.78
+    Banana 233.43
+    Cantaloupe 1022.61
+    Eggplant 468.84
+    Watermelon 461.12
+    Artichoke 1464.22
+    Celery 482.11
+    Thyme 632.46
+    Carrot 498.29
+    Radish 299.75
+    Bell_Pepper 213.27
+    Jicama 537.36
+    Parsnip 474.91
+    Endive 277.86
+    Passion_Fruit 311.53
+    Kohlrabi 189.30
+    Clementine 548.10
+    Kiwano 534.63
+    Kiwi 258.24
+    Dill 1145.65
+    Sage 295.42
+    Potato 598.06
+    Zucchini 543.21
+    Pear 797.10
+    Peach 559.58
+    Plum 271.17
+    Basil 222.21
+    Onion 812.52
+    Fig 405.91
+    Turnip 667.03
+    Pineapple 263.90
+    Honeydew 1294.52
+    Grapefruit 761.35
+    Pomegranate 1130.54
+    Berrechid 47940.25
+    Lettuce 527.82
+    Turnip 165.14
+    Brussels_Sprouts 486.42
+    Honeydew 1180.95
+    Rhubarb 411.67
+    Peas 146.87
+    Nectarine 450.83
+    Sweet_Potato 918.87
+    Bell_Pepper 241.37
+    Cranberry 795.70
+    Raspberry 458.96
+    Radish 314.88
+    Lime 533.67
+    Green_Beans 686.90
+    Pear 580.41
+    Guava 367.47
+    Watercress 797.29
+    Plantain 255.48
+    Beet 449.17
+    Pomegranate 1141.81
+    Passion_Fruit 95.85
+    Date 584.55
+    Okra 670.28
+    Cauliflower 346.11
+    Avocado 358.95
+    Bok_Choy 289.20
+    Parsnip 577.69
+    Fig 691.91
+    Sage 595.57
+    Starfruit 356.93
+    Asparagus 349.18
+    Zucchini 536.91
+    Spinach 657.11
+    Grapes 496.81
+    Pumpkin 226.47
+    Kiwi 518.89
+    Mango 135.23
+    Persimmon 343.13
+    Dill 283.14
+    Strawberry 486.52
+    Onion 573.27
+    Squash_Blossom 464.88
+    Papaya 592.66
+    Orange 302.33
+    Cabbage 102.76
+    Rutabaga 554.29
+    Rosemary 515.47
+    Chard 467.44
+    Kohlrabi 771.41
+    Plum 392.63
+    Cherry 534.80
+    Butternut_Squash 322.93
+    Tomato 462.96
+    Cactus_Pear 619.82
+    Cilantro 799.54
+    Kiwano 445.95
+    Watermelon 510.63
+    Yam 436.67
+    Peach 360.42
+    Broccoli 579.65
+    Basil 653.25
+    Collard_Greens 431.60
+    Cucumber 420.52
+    Grapefruit 969.04
+    Eggplant 333.02
+    Oregano 532.51
+    Celery 493.02
+    Coconut 842.12
+    Salsify 433.30
+    Kale 682.22
+    Ginger 527.53
+    Clementine 634.97
+    Artichoke 1531.50
+    Dragon_Fruit 358.81
+    Apple 415.71
+    Acorn_Squash 602.32
+    Lemon 603.49
+    Blueberry 345.42
+    Thyme 670.48
+    Mint 303.51
+    Jackfruit 514.93
+    Banana 488.91
+    Blackberry 554.90
+    Apricot 535.13
+    Jicama 547.83
+    Currant 546.91
+    Potato 320.66
+    Goji_Berry 188.98
+    Parsley 747.78
+    Cantaloupe 656.36
+    Garlic 463.54
+    Endive 258.73
+    Pineapple 557.49
+    Carrot 451.14
+    Ifrane 49980.38
+    Dragon_Fruit 318.90
+    Mint 515.88
+    Lettuce 649.39
+    Grapefruit 474.93
+    Sweet_Potato 269.84
+    Orange 908.93
+    Cucumber 318.42
+    Radish 529.44
+    Watermelon 523.57
+    Salsify 272.70
+    Raspberry 202.19
+    Avocado 525.87
+    Pomegranate 711.98
+    Kohlrabi 790.79
+    Guava 433.56
+    Peas 858.25
+    Asparagus 432.05
+    Banana 670.25
+    Dill 360.46
+    Cilantro 474.23
+    Jicama 383.17
+    Fig 800.76
+    Spinach 449.22
+    Basil 546.16
+    Plum 721.09
+    Strawberry 519.10
+    Peach 437.00
+    Watercress 380.02
+    Tomato 416.26
+    Kiwi 263.74
+    Currant 506.27
+    Oregano 453.25
+    Grapes 471.30
+    Pineapple 536.76
+    Rutabaga 787.82
+    Clementine 784.18
+    Cauliflower 508.55
+    Honeydew 1127.25
+    Lime 635.08
+    Cantaloupe 1203.28
+    Broccoli 180.37
+    Collard_Greens 624.01
+    Blackberry 452.28
+    Endive 408.55
+    Parsnip 641.68
+    Cranberry 849.13
+    Apple 371.07
+    Plantain 608.53
+    Kiwano 765.73
+    Parsley 491.99
+    Starfruit 665.68
+    Butternut_Squash 596.24
+    Okra 445.17
+    Apricot 742.55
+    Artichoke 832.33
+    Blueberry 599.04
+    Papaya 494.52
+    Cactus_Pear 506.08
+    Garlic 563.53
+    Kale 548.29
+    Passion_Fruit 381.80
+    Thyme 338.57
+    Rhubarb 518.86
+    Jackfruit 363.10
+    Coconut 889.51
+    Green_Beans 546.38
+    Lemon 533.00
+    Brussels_Sprouts 762.92
+    Cherry 506.31
+    Date 348.46
+    Eggplant 201.07
+    Goji_Berry 597.04
+    Cabbage 653.44
+    Bell_Pepper 636.33
+    Pear 434.77
+    Persimmon 547.21
+    Potato 450.35
+    Squash_Blossom 305.55
+    Bok_Choy 634.51
+    Nectarine 430.85
+    Acorn_Squash 150.15
+    Sage 332.32
+    Rosemary 295.23
+    Pumpkin 379.62
+    Beet 213.39
+    Yam 687.82
+    Carrot 584.84
+    Celery 446.47
+    Onion 525.57
+    Turnip 351.31
+    Mango 407.91
+    Ginger 993.43
+    Chard 482.16
+    Zucchini 491.47
+    Chefchaouen 49718.29
+    Lime 282.87
+    Cucumber 699.13
+    Brussels_Sprouts 126.42
+    Jicama 300.43
+    Kiwano 327.61
+    Kale 578.63
+    Papaya 487.34
+    Onion 779.60
+    Sweet_Potato 377.59
+    Guava 189.83
+    Bell_Pepper 519.11
+    Radish 385.66
+    Sage 947.25
+    Clementine 650.78
+    Cauliflower 788.95
+    Cranberry 1078.29
+    Chard 297.81
+    Oregano 241.31
+    Tomato 611.27
+    Lettuce 690.98
+    Date 137.10
+    Thyme 534.68
+    Apple 628.37
+    Parsnip 544.75
+    Grapes 624.61
+    Asparagus 690.41
+    Coconut 1482.27
+    Dill 557.96
+    Cherry 196.71
+    Zucchini 728.47
+    Banana 455.56
+    Cactus_Pear 740.52
+    Turnip 358.39
+    Watermelon 399.63
+    Honeydew 1068.46
+    Kohlrabi 372.51
+    Strawberry 435.48
+    Endive 640.21
+    Lemon 807.24
+    Nectarine 512.24
+    Raspberry 574.86
+    Yam 455.71
+    Pomegranate 1378.09
+    Rosemary 704.70
+    Goji_Berry 139.52
+    Cantaloupe 465.93
+    Avocado 482.02
+    Carrot 424.49
+    Apricot 327.72
+    Spinach 615.41
+    Cilantro 660.93
+    Grapefruit 274.04
+    Rutabaga 407.80
+    Currant 325.15
+    Broccoli 369.68
+    Orange 483.50
+    Plantain 538.24
+    Acorn_Squash 520.29
+    Beet 583.20
+    Basil 618.33
+    Pumpkin 473.34
+    Rhubarb 626.02
+    Bok_Choy 533.60
+    Garlic 719.51
+    Watercress 397.94
+    Pineapple 590.68
+    Mint 244.00
+    Jackfruit 359.77
+    Blueberry 374.45
+    Mango 659.32
+    Celery 186.10
+    Ginger 698.44
+    Squash_Blossom 459.76
+    Pear 282.34
+    Potato 412.34
+    Collard_Greens 64.77
+    Plum 754.10
+    Salsify 490.89
+    Kiwi 510.26
+    Persimmon 532.90
+    Peach 592.17
+    Fig 359.94
+    Eggplant 423.24
+    Cabbage 690.12
+    Starfruit 475.30
+    Parsley 662.45
+    Blackberry 419.34
+    Dragon_Fruit 724.59
+    Passion_Fruit 373.27
+    Butternut_Squash 200.22
+    Okra 318.58
+    Peas 452.84
+    Artichoke 1382.68
+    Green_Beans 646.98
+    Bab_Taza 51066.99
+    Artichoke 1000.21
+    Nectarine 722.78
+    Coconut 1158.90
+    Carrot 680.76
+    Acorn_Squash 707.96
+    Squash_Blossom 548.28
+    Bell_Pepper 406.42
+    Radish 813.31
+    Thyme 111.77
+    Celery 717.29
+    Grapes 723.46
+    Beet 503.20
+    Dill 641.21
+    Onion 567.19
+    Potato 214.74
+    Parsnip 372.05
+    Rhubarb 641.99
+    Parsley 658.46
+    Eggplant 660.30
+    Cantaloupe 1255.56
+    Lettuce 712.19
+    Pear 529.86
+    Pumpkin 593.29
+    Lime 317.15
+    Chard 492.83
+    Avocado 301.53
+    Butternut_Squash 506.82
+    Watercress 431.52
+    Cilantro 480.06
+    Rosemary 601.09
+    Mint 219.07
+    Cucumber 342.80
+    Fig 154.22
+    Starfruit 515.32
+    Papaya 548.32
+    Date 330.96
+    Grapefruit 657.84
+    Orange 633.14
+    Brussels_Sprouts 480.60
+    Peas 701.24
+    Salsify 426.34
+    Clementine 429.71
+    Strawberry 543.84
+    Watermelon 490.01
+    Blackberry 960.17
+    Okra 323.42
+    Asparagus 447.34
+    Blueberry 628.73
+    Dragon_Fruit 448.05
+    Pineapple 312.70
+    Goji_Berry 665.53
+    Ginger 506.70
+    Kohlrabi 768.40
+    Persimmon 377.85
+    Guava 451.98
+    Sage 473.20
+    Garlic 386.65
+    Rutabaga 157.18
+    Cherry 420.57
+    Peach 280.29
+    Plantain 805.52
+    Apple 382.61
+    Cactus_Pear 599.10
+    Endive 669.44
+    Spinach 292.78
+    Sweet_Potato 544.08
+    Jackfruit 559.76
+    Currant 974.98
+    Yam 476.43
+    Kiwi 368.56
+    Mango 602.03
+    Basil 358.26
+    Green_Beans 596.02
+    Kale 553.25
+    Raspberry 607.04
+    Apricot 562.52
+    Kiwano 409.96
+    Honeydew 504.38
+    Plum 701.10
+    Collard_Greens 121.30
+    Cabbage 387.64
+    Turnip 818.80
+    Broccoli 680.43
+    Cranberry 972.28
+    Lemon 465.20
+    Passion_Fruit 349.05
+    Tomato 606.45
+    Jicama 265.68
+    Banana 437.56
+    Bok_Choy 606.94
+    Zucchini 624.45
+    Oregano 450.81
+    Cauliflower 419.41
+    Pomegranate 1138.82
+    Asilah 51037.69
+    Butternut_Squash 435.86
+    Blackberry 806.13
+    Spinach 673.04
+    Parsley 408.59
+    Pumpkin 381.33
+    Collard_Greens 476.90
+    Green_Beans 388.49
+    Blueberry 380.96
+    Cucumber 681.59
+    Chard 621.72
+    Thyme 316.50
+    Radish 472.69
+    Peach 907.97
+    Basil 632.69
+    Pear 575.99
+    Watermelon 323.46
+    Okra 484.67
+    Celery 344.76
+    Strawberry 584.61
+    Guava 237.36
+    Cabbage 200.08
+    Honeydew 755.60
+    Currant 534.94
+    Beet 580.32
+    Cherry 899.67
+    Artichoke 1017.10
+    Ginger 591.03
+    Garlic 432.34
+    Kale 217.70
+    Passion_Fruit 633.24
+    Pomegranate 453.70
+    Carrot 414.27
+    Rhubarb 353.49
+    Bell_Pepper 365.02
+    Persimmon 499.37
+    Avocado 429.49
+    Grapes 486.11
+    Kohlrabi 518.63
+    Salsify 456.52
+    Parsnip 458.97
+    Squash_Blossom 559.73
+    Asparagus 218.57
+    Raspberry 484.51
+    Jicama 791.32
+    Cactus_Pear 323.68
+    Goji_Berry 505.74
+    Apple 319.88
+    Cantaloupe 713.92
+    Turnip 547.31
+    Acorn_Squash 568.87
+    Rosemary 528.33
+    Oregano 830.75
+    Jackfruit 692.93
+    Clementine 507.78
+    Nectarine 458.21
+    Yam 645.07
+    Eggplant 439.93
+    Watercress 670.40
+    Pineapple 765.92
+    Plum 309.14
+    Orange 945.76
+    Brussels_Sprouts 463.03
+    Lime 726.97
+    Mint 634.89
+    Kiwi 291.69
+    Broccoli 331.41
+    Rutabaga 473.43
+    Papaya 691.41
+    Bok_Choy 468.95
+    Sweet_Potato 290.86
+    Coconut 1032.02
+    Cranberry 800.88
+    Date 606.62
+    Mango 582.87
+    Cauliflower 501.66
+    Banana 754.88
+    Tomato 623.71
+    Lettuce 457.82
+    Endive 700.25
+    Fig 818.83
+    Dill 181.47
+    Cilantro 428.85
+    Starfruit 545.70
+    Sage 367.26
+    Potato 859.51
+    Kiwano 696.22
+    Peas 853.42
+    Lemon 670.33
+    Plantain 639.97
+    Dragon_Fruit 570.05
+    Grapefruit 288.51
+    Apricot 530.59
+    Zucchini 580.17
+    Onion 312.81
+    Tichka 47713.16
+    Cabbage 561.65
+    Starfruit 211.50
+    Papaya 371.27
+    Garlic 323.02
+    Kohlrabi 331.49
+    Pear 598.81
+    Cantaloupe 836.78
+    Jackfruit 706.63
+    Butternut_Squash 507.48
+    Pumpkin 620.76
+    Tomato 507.00
+    Banana 315.23
+    Green_Beans 242.36
+    Fig 653.99
+    Ginger 480.47
+    Rhubarb 601.03
+    Coconut 400.50
+    Artichoke 746.49
+    Strawberry 514.75
+    Broccoli 794.35
+    Date 746.46
+    Beet 550.86
+    Apricot 169.40
+    Passion_Fruit 339.86
+    Collard_Greens 468.04
+    Celery 423.08
+    Basil 323.84
+    Cactus_Pear 435.90
+    Apple 236.59
+    Guava 366.34
+    Kiwi 575.07
+    Squash_Blossom 543.31
+    Cranberry 951.99
+    Cauliflower 667.11
+    Persimmon 161.79
+    Lime 341.92
+    Rutabaga 454.37
+    Honeydew 1562.11
+    Lettuce 593.53
+    Kale 613.50
+    Zucchini 266.86
+    Blackberry 330.93
+    Peach 216.34
+    Orange 308.33
+    Asparagus 678.58
+    Blueberry 667.99
+    Rosemary 388.91
+    Peas 489.70
+    Kiwano 485.11
+    Radish 319.73
+    Cilantro 435.36
+    Grapefruit 346.49
+    Cucumber 590.79
+    Clementine 306.85
+    Mint 912.94
+    Nectarine 436.26
+    Grapes 624.11
+    Dill 393.30
+    Sweet_Potato 439.46
+    Mango 384.53
+    Sage 577.44
+    Eggplant 707.85
+    Watermelon 565.78
+    Brussels_Sprouts 482.42
+    Dragon_Fruit 526.56
+    Goji_Berry 737.89
+    Okra 682.21
+    Jicama 626.72
+    Lemon 305.01
+    Bok_Choy 248.49
+    Potato 505.18
+    Turnip 531.33
+    Pomegranate 1244.05
+    Watercress 531.24
+    Endive 695.41
+    Salsify 301.02
+    Oregano 833.89
+    Onion 393.90
+    Cherry 435.00
+    Yam 220.52
+    Bell_Pepper 582.35
+    Chard 468.89
+    Plantain 310.33
+    Pineapple 431.15
+    Carrot 427.43
+    Raspberry 336.91
+    Currant 429.36
+    Plum 579.43
+    Spinach 820.13
+    Acorn_Squash 648.81
+    Parsley 645.14
+    Avocado 284.47
+    Parsnip 318.68
+    Thyme 404.97
+    Khouribga 47250.02
+    Dill 558.99
+    Acorn_Squash 337.59
+    Butternut_Squash 409.42
+    Cherry 378.53
+    Mint 813.98
+    Spinach 322.60
+    Peach 324.44
+    Kiwano 738.14
+    Grapes 585.85
+    Carrot 849.21
+    Persimmon 545.18
+    Starfruit 645.17
+    Date 280.87
+    Currant 653.66
+    Pineapple 386.29
+    Orange 419.69
+    Okra 683.12
+    Fig 325.46
+    Kohlrabi 438.41
+    Artichoke 1067.71
+    Thyme 537.75
+    Pear 559.09
+    Passion_Fruit 534.69
+    Kiwi 696.54
+    Plum 563.31
+    Jicama 596.61
+    Beet 488.47
+    Coconut 896.60
+    Cantaloupe 1473.61
+    Kale 421.03
+    Radish 439.26
+    Strawberry 359.63
+    Mango 606.89
+    Pomegranate 917.31
+    Bok_Choy 509.29
+    Cilantro 206.38
+    Watermelon 463.37
+    Rutabaga 523.47
+    Squash_Blossom 857.37
+    Chard 639.32
+    Blueberry 380.15
+    Cabbage 394.57
+    Rhubarb 159.94
+    Brussels_Sprouts 488.72
+    Tomato 152.77
+    Dragon_Fruit 498.40
+    Rosemary 600.17
+    Clementine 921.69
+    Cactus_Pear 550.31
+    Cucumber 310.05
+    Celery 540.65
+    Nectarine 199.95
+    Raspberry 427.81
+    Apple 411.59
+    Avocado 502.24
+    Endive 259.49
+    Potato 250.36
+    Turnip 276.77
+    Salsify 561.32
+    Peas 374.17
+    Blackberry 309.22
+    Garlic 471.92
+    Papaya 383.15
+    Parsnip 632.99
+    Sage 636.05
+    Green_Beans 285.60
+    Parsley 409.63
+    Sweet_Potato 515.09
+    Goji_Berry 503.42
+    Cauliflower 278.80
+    Lettuce 101.23
+    Collard_Greens 267.70
+    Bell_Pepper 666.66
+    Guava 523.50
+    Plantain 687.61
+    Ginger 368.49
+    Banana 363.88
+    Broccoli 576.10
+    Yam 352.78
+    Pumpkin 485.28
+    Cranberry 886.91
+    Grapefruit 230.59
+    Lime 337.49
+    Zucchini 477.38
+    Lemon 475.84
+    Jackfruit 357.58
+    Watercress 512.79
+    Basil 610.36
+    Eggplant 594.89
+    Onion 133.13
+    Honeydew 943.63
+    Asparagus 538.48
+    Apricot 596.01
+    Oregano 420.42
+    Skhirate 50155.01
+    Cantaloupe 913.00
+    Cilantro 489.46
+    Cucumber 641.35
+    Papaya 414.85
+    Peas 406.76
+    Potato 346.12
+    Jackfruit 514.04
+    Chard 360.11
+    Radish 1207.93
+    Kohlrabi 732.00
+    Thyme 186.68
+    Plum 581.27
+    Basil 494.96
+    Pineapple 453.54
+    Mint 415.31
+    Persimmon 426.33
+    Strawberry 436.42
+    Parsnip 418.79
+    Dragon_Fruit 414.50
+    Okra 829.20
+    Cherry 367.22
+    Lettuce 628.87
+    Sweet_Potato 543.95
+    Passion_Fruit 618.39
+    Sage 524.91
+    Kiwi 289.03
+    Pomegranate 948.92
+    Cranberry 873.46
+    Pumpkin 852.30
+    Celery 666.40
+    Kiwano 462.62
+    Kale 452.65
+    Lemon 296.79
+    Butternut_Squash 234.72
+    Asparagus 620.47
+    Artichoke 844.28
+    Watermelon 564.61
+    Plantain 387.78
+    Broccoli 528.22
+    Fig 324.70
+    Green_Beans 863.25
+    Date 541.65
+    Raspberry 653.01
+    Acorn_Squash 852.97
+    Jicama 642.55
+    Cactus_Pear 460.65
+    Endive 495.17
+    Orange 732.48
+    Zucchini 153.99
+    Grapes 558.89
+    Yam 379.06
+    Avocado 447.11
+    Carrot 492.71
+    Salsify 415.80
+    Honeydew 991.19
+    Brussels_Sprouts 437.26
+    Turnip 602.76
+    Squash_Blossom 680.78
+    Apple 698.73
+    Bell_Pepper 499.80
+    Rosemary 440.84
+    Blueberry 651.30
+    Watercress 192.54
+    Nectarine 1031.79
+    Eggplant 368.22
+    Apricot 620.63
+    Goji_Berry 797.97
+    Lime 518.79
+    Rhubarb 271.57
+    Cauliflower 288.63
+    Beet 394.01
+    Mango 416.02
+    Banana 623.40
+    Spinach 38.11
+    Oregano 473.43
+    Ginger 247.10
+    Dill 350.27
+    Pear 517.54
+    Starfruit 337.57
+    Peach 265.17
+    Clementine 640.76
+    Onion 741.96
+    Coconut 801.84
+    Tomato 998.61
+    Guava 576.77
+    Parsley 563.56
+    Garlic 299.61
+    Collard_Greens 727.49
+    Grapefruit 396.91
+    Cabbage 384.80
+    Rutabaga 587.41
+    Blackberry 141.33
+    Bok_Choy 500.45
+    Currant 635.89
+    Ksar_es_Seghir 50306.06
+    Nectarine 545.59
+    Apricot 649.25
+    Date 471.31
+    Ginger 635.74
+    Cilantro 309.06
+    Salsify 364.22
+    Plantain 772.90
+    Plum 443.82
+    Dragon_Fruit 112.41
+    Onion 633.86
+    Grapefruit 401.21
+    Basil 618.06
+    Spinach 936.51
+    Broccoli 248.81
+    Turnip 621.25
+    Peas 297.47
+    Blackberry 931.13
+    Cantaloupe 878.39
+    Bok_Choy 637.26
+    Kiwano 826.54
+    Bell_Pepper 423.04
+    Oregano 373.54
+    Green_Beans 588.21
+    Chard 794.03
+    Garlic 384.04
+    Acorn_Squash 580.35
+    Mango 595.87
+    Kohlrabi 850.28
+    Thyme 452.01
+    Pumpkin 514.90
+    Lettuce 551.22
+    Tomato 545.06
+    Rhubarb 564.85
+    Artichoke 970.10
+    Currant 326.37
+    Grapes 550.22
+    Pear 177.65
+    Passion_Fruit 346.95
+    Watermelon 488.09
+    Cranberry 1566.24
+    Persimmon 843.24
+    Orange 479.46
+    Brussels_Sprouts 376.20
+    Okra 425.33
+    Sweet_Potato 297.49
+    Apple 760.96
+    Eggplant 589.00
+    Squash_Blossom 238.94
+    Papaya 707.40
+    Cactus_Pear 540.33
+    Mint 754.69
+    Peach 307.31
+    Strawberry 437.92
+    Kiwi 389.98
+    Butternut_Squash 568.38
+    Endive 542.45
+    Zucchini 489.22
+    Lemon 172.33
+    Collard_Greens 352.79
+    Starfruit 495.54
+    Goji_Berry 857.13
+    Jackfruit 454.98
+    Cauliflower 354.71
+    Cucumber 715.11
+    Radish 409.80
+    Beet 269.13
+    Blueberry 701.24
+    Sage 456.13
+    Cabbage 498.27
+    Cherry 143.67
+    Rutabaga 590.91
+    Carrot 257.91
+    Honeydew 1074.94
+    Yam 779.26
+    Pomegranate 656.16
+    Avocado 173.46
+    Jicama 143.53
+    Fig 281.86
+    Banana 630.90
+    Rosemary 99.51
+    Guava 367.82
+    Kale 555.70
+    Watercress 419.11
+    Parsley 531.64
+    Pineapple 540.14
+    Raspberry 588.50
+    Celery 619.04
+    Dill 627.50
+    Clementine 815.50
+    Lime 729.33
+    Parsnip 499.54
+    Coconut 945.71
+    Asparagus 418.75
+    Potato 352.40
+    Taza 46289.25
+    Coconut 616.59
+    Bok_Choy 335.08
+    Strawberry 793.33
+    Parsley 437.64
+    Mango 651.07
+    Rosemary 466.13
+    Broccoli 409.62
+    Cranberry 1383.40
+    Bell_Pepper 402.38
+    Fig 608.18
+    Okra 404.94
+    Cauliflower 567.74
+    Salsify 531.24
+    Asparagus 275.63
+    Cilantro 577.62
+    Raspberry 360.84
+    Kiwi 306.77
+    Date 278.20
+    Jackfruit 738.87
+    Avocado 481.12
+    Lime 372.63
+    Persimmon 387.96
+    Celery 558.81
+    Honeydew 949.49
+    Jicama 789.03
+    Zucchini 323.52
+    Eggplant 238.35
+    Kiwano 516.37
+    Mint 217.28
+    Pomegranate 529.25
+    Blueberry 381.30
+    Cactus_Pear 665.42
+    Thyme 403.39
+    Plantain 554.89
+    Acorn_Squash 748.88
+    Watermelon 244.17
+    Watercress 778.42
+    Starfruit 705.16
+    Grapes 241.52
+    Endive 377.38
+    Onion 641.99
+    Cherry 282.97
+    Peas 603.99
+    Carrot 413.19
+    Cantaloupe 909.10
+    Kale 661.04
+    Pumpkin 1039.48
+    Papaya 553.11
+    Green_Beans 372.78
+    Oregano 487.60
+    Brussels_Sprouts 407.85
+    Artichoke 536.75
+    Collard_Greens 708.19
+    Ginger 195.97
+    Yam 362.09
+    Sage 482.89
+    Guava 648.49
+    Cabbage 434.69
+    Goji_Berry 667.42
+    Spinach 261.07
+    Banana 210.48
+    Pineapple 287.64
+    Dragon_Fruit 429.08
+    Apple 696.43
+    Plum 574.01
+    Nectarine 527.12
+    Peach 209.87
+    Parsnip 637.28
+    Rhubarb 425.83
+    Orange 223.98
+    Kohlrabi 359.24
+    Rutabaga 557.62
+    Currant 514.64
+    Sweet_Potato 470.39
+    Clementine 519.97
+    Passion_Fruit 326.68
+    Apricot 534.26
+    Basil 595.27
+    Radish 780.89
+    Garlic 330.74
+    Turnip 222.41
+    Dill 602.23
+    Beet 398.22
+    Squash_Blossom 539.06
+    Tomato 154.49
+    Lettuce 307.09
+    Chard 684.64
+    Cucumber 513.25
+    Blackberry 383.82
+    Potato 320.10
+    Pear 651.94
+    Butternut_Squash 433.93
+    Grapefruit 267.44
+    Lemon 318.94
+    Chichaoua 47970.74
+    Blueberry 907.54
+    Potato 354.00
+    Basil 612.91
+    Orange 360.42
+    Bell_Pepper 477.24
+    Thyme 450.40
+    Strawberry 478.61
+    Rosemary 274.46
+    Cabbage 574.21
+    Dill 294.92
+    Lemon 440.21
+    Goji_Berry 629.07
+    Onion 364.43
+    Dragon_Fruit 225.43
+    Nectarine 362.59
+    Clementine 390.36
+    Parsley 603.94
+    Radish 461.68
+    Jackfruit 535.04
+    Tomato 307.46
+    Cherry 497.28
+    Endive 294.64
+    Lettuce 321.14
+    Mango 410.46
+    Plantain 735.24
+    Artichoke 1207.26
+    Apple 382.50
+    Spinach 608.69
+    Grapes 373.52
+    Fig 290.49
+    Avocado 291.96
+    Kiwi 507.89
+    Blackberry 777.79
+    Watercress 363.02
+    Cantaloupe 1456.62
+    Zucchini 747.23
+    Persimmon 406.92
+    Mint 536.83
+    Green_Beans 499.10
+    Coconut 1117.62
+    Plum 210.39
+    Brussels_Sprouts 164.44
+    Acorn_Squash 218.43
+    Collard_Greens 272.66
+    Honeydew 992.20
+    Garlic 744.42
+    Pineapple 526.33
+    Cactus_Pear 530.27
+    Raspberry 742.17
+    Parsnip 133.01
+    Cilantro 113.65
+    Butternut_Squash 189.96
+    Banana 626.35
+    Ginger 465.45
+    Celery 761.45
+    Oregano 877.40
+    Apricot 332.74
+    Date 229.67
+    Currant 319.34
+    Squash_Blossom 449.59
+    Kale 631.71
+    Kohlrabi 433.56
+    Lime 290.38
+    Starfruit 779.73
+    Rutabaga 629.06
+    Watermelon 405.47
+    Cranberry 1049.16
+    Broccoli 437.67
+    Beet 212.48
+    Bok_Choy 540.61
+    Okra 273.37
+    Eggplant 317.63
+    Salsify 506.77
+    Jicama 723.12
+    Asparagus 723.12
+    Grapefruit 354.24
+    Sweet_Potato 480.13
+    Peach 492.75
+    Carrot 499.70
+    Cauliflower 689.90
+    Pumpkin 546.51
+    Turnip 186.24
+    Pear 711.57
+    Pomegranate 993.77
+    Peas 704.03
+    Yam 389.70
+    Rhubarb 349.01
+    Kiwano 448.35
+    Sage 821.82
+    Papaya 541.09
+    Passion_Fruit 700.34
+    Chard 659.32
+    Guava 185.95
+    Cucumber 431.44
+    Layoune 51039.73
+    Sage 626.75
+    Kohlrabi 420.01
+    Peach 511.61
+    Grapes 426.35
+    Honeydew 1099.81
+    Broccoli 242.82
+    Parsley 471.04
+    Bok_Choy 426.73
+    Watercress 343.44
+    Dill 683.81
+    Yam 579.92
+    Dragon_Fruit 445.06
+    Eggplant 474.69
+    Pumpkin 484.57
+    Nectarine 889.56
+    Parsnip 349.14
+    Sweet_Potato 326.00
+    Apple 531.23
+    Jackfruit 329.60
+    Beet 252.68
+    Chard 708.74
+    Clementine 419.81
+    Cilantro 864.68
+    Jicama 729.93
+    Pomegranate 953.35
+    Cabbage 517.15
+    Fig 631.45
+    Rhubarb 201.76
+    Rutabaga 902.11
+    Blueberry 223.52
+    Currant 432.78
+    Kiwano 499.54
+    Cranberry 1240.88
+    Lemon 287.21
+    Potato 412.62
+    Orange 463.60
+    Bell_Pepper 714.83
+    Butternut_Squash 612.74
+    Cantaloupe 987.52
+    Papaya 430.09
+    Strawberry 671.20
+    Cherry 568.09
+    Kale 264.52
+    Persimmon 406.04
+    Asparagus 470.38
+    Acorn_Squash 398.54
+    Watermelon 296.40
+    Pear 399.80
+    Plum 384.29
+    Salsify 345.67
+    Date 245.52
+    Raspberry 919.09
+    Brussels_Sprouts 748.44
+    Plantain 231.77
+    Mint 411.13
+    Cactus_Pear 890.71
+    Squash_Blossom 340.22
+    Apricot 326.14
+    Cucumber 471.23
+    Rosemary 577.98
+    Okra 496.29
+    Mango 805.68
+    Cauliflower 527.18
+    Guava 698.76
+    Radish 664.65
+    Basil 693.68
+    Peas 503.07
+    Oregano 433.54
+    Grapefruit 508.31
+    Turnip 639.23
+    Banana 470.10
+    Tomato 758.64
+    Pineapple 566.21
+    Collard_Greens 414.41
+    Goji_Berry 555.46
+    Onion 356.85
+    Zucchini 434.12
+    Blackberry 363.75
+    Starfruit 638.13
+    Spinach 497.68
+    Kiwi 471.69
+    Artichoke 1023.33
+    Garlic 702.04
+    Avocado 576.76
+    Celery 451.84
+    Passion_Fruit 462.57
+    Ginger 357.45
+    Lime 453.32
+    Lettuce 1167.79
+    Carrot 463.92
+    Coconut 1266.92
+    Thyme 190.82
+    Endive 338.88
+    Green_Beans 570.37
+    Oulad_Teima 53052.54
+    Mango 216.99
+    Currant 271.62
+    Artichoke 654.23
+    Sweet_Potato 441.53
+    Plantain 823.87
+    Orange 308.00
+    Banana 785.37
+    Peach 518.64
+    Brussels_Sprouts 565.53
+    Apricot 146.70
+    Cranberry 1183.05
+    Guava 336.85
+    Pineapple 764.59
+    Basil 444.88
+    Celery 668.40
+    Squash_Blossom 433.94
+    Dragon_Fruit 497.97
+    Cactus_Pear 653.77
+    Kiwano 124.76
+    Endive 322.92
+    Onion 508.83
+    Strawberry 358.15
+    Ginger 940.56
+    Starfruit 704.53
+    Butternut_Squash 394.40
+    Raspberry 744.30
+    Apple 610.53
+    Kale 292.91
+    Cabbage 601.23
+    Turnip 617.27
+    Coconut 1539.41
+    Lettuce 814.15
+    Yam 762.04
+    Grapes 985.08
+    Tomato 431.28
+    Lime 276.92
+    Jackfruit 510.86
+    Cherry 419.52
+    Grapefruit 279.80
+    Broccoli 159.39
+    Salsify 809.04
+    Cantaloupe 1173.96
+    Sage 711.94
+    Pumpkin 508.19
+    Blueberry 422.55
+    Plum 695.58
+    Rhubarb 586.82
+    Chard 667.26
+    Honeydew 1054.76
+    Bok_Choy 765.53
+    Parsley 786.61
+    Passion_Fruit 571.55
+    Rutabaga 581.13
+    Cauliflower 875.46
+    Cucumber 505.82
+    Okra 442.74
+    Oregano 462.04
+    Thyme 641.86
+    Watercress 205.90
+    Date 367.99
+    Jicama 299.25
+    Rosemary 479.77
+    Pomegranate 1353.65
+    Potato 707.26
+    Avocado 711.55
+    Bell_Pepper 554.74
+    Papaya 350.38
+    Collard_Greens 598.91
+    Cilantro 904.91
+    Beet 338.40
+    Lemon 882.27
+    Nectarine 246.66
+    Spinach 439.93
+    Parsnip 318.30
+    Green_Beans 200.26
+    Pear 198.54
+    Radish 920.20
+    Clementine 510.80
+    Kohlrabi 648.83
+    Blackberry 278.19
+    Goji_Berry 427.38
+    Asparagus 553.90
+    Mint 360.84
+    Dill 488.37
+    Persimmon 658.03
+    Garlic 645.29
+    Peas 181.42
+    Watermelon 377.95
+    Kiwi 876.27
+    Eggplant 705.78
+    Carrot 516.65
+    Acorn_Squash 453.15
+    Zucchini 444.06
+    Fig 469.15
+    Oujda_Angad 49811.27
+    Rosemary 331.80
+    Honeydew 1260.71
+    Nectarine 426.88
+    Kiwano 357.20
+    Rhubarb 406.50
+    Papaya 444.02
+    Pomegranate 1180.49
+    Lime 535.00
+    Grapefruit 419.14
+    Peach 475.48
+    Bok_Choy 560.88
+    Guava 483.88
+    Cilantro 465.69
+    Goji_Berry 496.30
+    Coconut 701.89
+    Sweet_Potato 308.56
+    Green_Beans 516.31
+    Fig 435.93
+    Broccoli 413.27
+    Pumpkin 779.95
+    Clementine 481.33
+    Cauliflower 688.85
+    Blueberry 439.83
+    Turnip 642.42
+    Tomato 755.64
+    Rutabaga 394.56
+    Apple 597.13
+    Grapes 465.26
+    Okra 449.78
+    Potato 252.34
+    Passion_Fruit 803.00
+    Brussels_Sprouts 550.85
+    Celery 443.84
+    Watermelon 545.30
+    Oregano 533.03
+    Eggplant 415.56
+    Endive 743.97
+    Pear 605.70
+    Yam 668.51
+    Jackfruit 612.77
+    Dragon_Fruit 383.59
+    Garlic 378.57
+    Apricot 495.50
+    Lemon 439.95
+    Artichoke 382.33
+    Cactus_Pear 705.07
+    Sage 700.68
+    Currant 371.73
+    Cherry 496.88
+    Cranberry 1116.78
+    Blackberry 292.31
+    Parsley 336.73
+    Jicama 562.73
+    Plum 715.52
+    Butternut_Squash 224.03
+    Starfruit 561.49
+    Lettuce 319.92
+    Peas 569.04
+    Spinach 535.92
+    Raspberry 109.40
+    Salsify 651.87
+    Kiwi 393.19
+    Bell_Pepper 174.82
+    Thyme 800.82
+    Orange 895.66
+    Cantaloupe 972.04
+    Kale 220.38
+    Cabbage 463.77
+    Acorn_Squash 588.41
+    Carrot 421.33
+    Watercress 647.96
+    Onion 764.54
+    Date 736.10
+    Pineapple 433.98
+    Mango 508.83
+    Mint 375.33
+    Avocado 352.10
+    Banana 261.63
+    Collard_Greens 477.13
+    Chard 944.53
+    Dill 398.93
+    Strawberry 507.22
+    Radish 549.02
+    Plantain 228.68
+    Zucchini 487.78
+    Squash_Blossom 688.14
+    Parsnip 845.22
+    Beet 334.83
+    Kohlrabi 789.66
+    Asparagus 601.92
+    Basil 221.23
+    Persimmon 433.06
+    Ginger 618.05
+    Cucumber 235.39
+    Imzouren 49403.91
+    Jackfruit 262.84
+    Cactus_Pear 616.65
+    Parsnip 389.06
+    Mint 715.08
+    Nectarine 544.94
+    Cucumber 511.57
+    Kiwano 107.56
+    Rutabaga 262.94
+    Mango 585.10
+    Asparagus 418.74
+    Persimmon 225.22
+    Squash_Blossom 273.80
+    Collard_Greens 643.90
+    Plum 449.13
+    Bell_Pepper 390.35
+    Celery 805.35
+    Basil 455.88
+    Cabbage 366.97
+    Blueberry 481.57
+    Papaya 545.42
+    Kiwi 510.36
+    Potato 380.66
+    Currant 430.61
+    Cherry 391.16
+    Pear 225.50
+    Blackberry 467.29
+    Carrot 788.95
+    Chard 483.82
+    Pumpkin 364.84
+    Lettuce 377.50
+    Goji_Berry 734.85
+    Onion 535.52
+    Bok_Choy 355.65
+    Cranberry 1182.11
+    Peach 353.79
+    Fig 430.31
+    Passion_Fruit 207.76
+    Lime 512.13
+    Honeydew 918.17
+    Kale 715.15
+    Lemon 421.76
+    Rhubarb 652.31
+    Strawberry 611.42
+    Dill 383.37
+    Watermelon 456.73
+    Coconut 1168.49
+    Spinach 629.82
+    Ginger 724.03
+    Broccoli 496.64
+    Green_Beans 537.17
+    Rosemary 254.55
+    Jicama 547.82
+    Sage 776.93
+    Cilantro 587.56
+    Acorn_Squash 425.32
+    Garlic 329.77
+    Okra 398.28
+    Radish 640.58
+    Watercress 561.84
+    Kohlrabi 555.30
+    Clementine 612.93
+    Grapefruit 837.16
+    Orange 422.38
+    Tomato 192.17
+    Beet 696.30
+    Apricot 650.36
+    Date 313.77
+    Peas 808.13
+    Turnip 376.42
+    Cantaloupe 1267.30
+    Apple 473.70
+    Eggplant 606.79
+    Butternut_Squash 887.83
+    Brussels_Sprouts 228.63
+    Dragon_Fruit 504.60
+    Guava 428.99
+    Plantain 660.08
+    Grapes 243.69
+    Cauliflower 424.89
+    Zucchini 604.91
+    Sweet_Potato 324.53
+    Salsify 352.67
+    Endive 796.18
+    Oregano 794.84
+    Artichoke 658.39
+    Yam 374.72
+    Thyme 487.72
+    Avocado 568.76
+    Pomegranate 1073.89
+    Raspberry 622.94
+    Pineapple 244.74
+    Banana 323.43
+    Starfruit 385.47
+    Parsley 576.71
+    Guelmim 49878.69
+    Lettuce 599.60
+    Squash_Blossom 829.52
+    Passion_Fruit 979.34
+    Sage 255.85
+    Strawberry 369.46
+    Grapes 571.69
+    Sweet_Potato 646.93
+    Onion 694.17
+    Butternut_Squash 435.37
+    Watercress 783.18
+    Pumpkin 462.13
+    Currant 457.69
+    Cabbage 353.27
+    Jackfruit 635.12
+    Date 675.13
+    Garlic 868.51
+    Basil 321.19
+    Coconut 1089.71
+    Parsnip 256.17
+    Yam 619.70
+    Green_Beans 380.72
+    Dill 670.53
+    Potato 745.96
+    Cranberry 1422.21
+    Artichoke 870.18
+    Beet 362.41
+    Mint 418.75
+    Rhubarb 396.63
+    Pomegranate 753.19
+    Radish 508.19
+    Oregano 695.85
+    Fig 299.20
+    Guava 414.71
+    Kohlrabi 669.41
+    Okra 563.00
+    Watermelon 190.61
+    Lemon 365.84
+    Blackberry 674.58
+    Goji_Berry 639.60
+    Carrot 447.76
+    Thyme 210.28
+    Tomato 385.85
+    Cherry 386.13
+    Rosemary 476.83
+    Spinach 454.55
+    Peas 330.97
+    Kiwi 525.51
+    Bell_Pepper 497.68
+    Turnip 383.18
+    Collard_Greens 238.06
+    Brussels_Sprouts 458.44
+    Cauliflower 430.26
+    Raspberry 582.15
+    Papaya 424.50
+    Celery 469.49
+    Pear 306.39
+    Pineapple 729.57
+    Honeydew 745.55
+    Orange 684.74
+    Blueberry 552.07
+    Clementine 417.22
+    Dragon_Fruit 415.71
+    Grapefruit 331.77
+    Bok_Choy 496.58
+    Starfruit 485.70
+    Asparagus 625.36
+    Cucumber 451.34
+    Broccoli 495.89
+    Apricot 251.93
+    Kiwano 702.96
+    Mango 802.92
+    Nectarine 448.18
+    Rutabaga 415.46
+    Chard 329.26
+    Acorn_Squash 608.13
+    Plum 734.56
+    Kale 328.93
+    Jicama 313.54
+    Endive 243.17
+    Avocado 423.45
+    Ginger 556.54
+    Cactus_Pear 383.77
+    Lime 358.46
+    Peach 553.75
+    Cilantro 448.77
+    Plantain 288.97
+    Cantaloupe 704.97
+    Banana 667.62
+    Salsify 521.94
+    Apple 722.11
+    Zucchini 738.05
+    Parsley 668.61
+    Persimmon 644.71
+    Eggplant 633.10
+    Bab_Berred 48551.95
+    Oregano 397.87
+    Strawberry 664.47
+    Goji_Berry 466.09
+    Broccoli 426.84
+    Pineapple 365.07
+    Cherry 218.20
+    Lemon 303.42
+    Persimmon 377.32
+    Jackfruit 474.63
+    Dragon_Fruit 240.53
+    Peach 736.01
+    Parsnip 564.70
+    Starfruit 900.52
+    Clementine 671.11
+    Watermelon 417.52
+    Asparagus 362.38
+    Salsify 453.13
+    Squash_Blossom 541.21
+    Spinach 364.67
+    Bell_Pepper 462.94
+    Rosemary 499.00
+    Currant 401.74
+    Avocado 544.84
+    Tomato 306.15
+    Watercress 440.29
+    Blackberry 218.80
+    Guava 428.62
+    Green_Beans 470.64
+    Kiwano 495.38
+    Celery 781.09
+    Passion_Fruit 541.88
+    Zucchini 555.57
+    Chard 240.74
+    Cranberry 901.17
+    Pomegranate 555.10
+    Carrot 564.46
+    Ginger 654.08
+    Kohlrabi 218.47
+    Grapefruit 924.43
+    Papaya 517.74
+    Cucumber 291.78
+    Orange 256.10
+    Cactus_Pear 735.73
+    Rutabaga 309.97
+    Collard_Greens 425.70
+    Plantain 410.77
+    Cilantro 474.46
+    Bok_Choy 284.02
+    Date 661.87
+    Coconut 1072.62
+    Acorn_Squash 661.49
+    Grapes 561.16
+    Beet 537.37
+    Garlic 309.09
+    Brussels_Sprouts 576.46
+    Cauliflower 589.50
+    Honeydew 1209.01
+    Raspberry 415.09
+    Lime 798.56
+    Mint 810.05
+    Thyme 396.72
+    Fig 329.37
+    Sweet_Potato 380.93
+    Okra 270.07
+    Artichoke 939.34
+    Peas 265.78
+    Banana 689.81
+    Rhubarb 498.52
+    Cabbage 585.03
+    Blueberry 403.24
+    Turnip 242.22
+    Kiwi 661.72
+    Cantaloupe 598.88
+    Apricot 732.15
+    Parsley 491.40
+    Basil 529.51
+    Kale 275.70
+    Mango 653.59
+    Dill 569.89
+    Onion 348.67
+    Endive 528.78
+    Yam 544.27
+    Apple 243.69
+    Butternut_Squash 660.93
+    Potato 158.97
+    Pear 351.29
+    Plum 790.98
+    Eggplant 781.81
+    Nectarine 744.06
+    Jicama 498.89
+    Radish 820.93
+    Pumpkin 468.00
+    Sage 473.88
+    Lettuce 563.31
+    Rabat 46966.48
+    Salsify 551.31
+    Collard_Greens 627.07
+    Blueberry 404.40
+    Parsnip 259.42
+    Blackberry 254.10
+    Green_Beans 887.06
+    Tomato 675.21
+    Radish 595.57
+    Spinach 408.95
+    Lettuce 253.26
+    Artichoke 726.12
+    Acorn_Squash 360.41
+    Rhubarb 479.53
+    Zucchini 328.48
+    Goji_Berry 242.28
+    Thyme 524.88
+    Plantain 610.01
+    Beet 630.24
+    Onion 497.33
+    Starfruit 384.71
+    Cactus_Pear 717.44
+    Squash_Blossom 296.91
+    Pineapple 622.62
+    Yam 438.01
+    Passion_Fruit 376.41
+    Honeydew 1264.74
+    Pear 365.06
+    Coconut 741.16
+    Cantaloupe 770.86
+    Date 194.83
+    Kale 586.69
+    Strawberry 410.89
+    Kiwi 402.12
+    Pumpkin 382.80
+    Watercress 618.14
+    Avocado 542.78
+    Jicama 508.40
+    Cabbage 295.06
+    Fig 620.30
+    Persimmon 320.74
+    Apple 401.54
+    Cherry 505.81
+    Asparagus 370.98
+    Potato 340.94
+    Mango 518.72
+    Grapefruit 463.08
+    Basil 418.85
+    Nectarine 443.86
+    Carrot 242.63
+    Parsley 769.45
+    Rutabaga 440.63
+    Pomegranate 795.34
+    Orange 617.62
+    Apricot 546.89
+    Cilantro 403.61
+    Peas 624.02
+    Cranberry 891.17
+    Garlic 162.55
+    Chard 548.54
+    Sweet_Potato 458.64
+    Mint 391.12
+    Bok_Choy 289.56
+    Eggplant 408.38
+    Dragon_Fruit 250.09
+    Turnip 355.18
+    Cauliflower 543.95
+    Plum 728.57
+    Broccoli 337.12
+    Guava 455.50
+    Bell_Pepper 855.54
+    Sage 907.91
+    Dill 682.16
+    Lemon 413.13
+    Brussels_Sprouts 208.56
+    Clementine 502.52
+    Kiwano 415.11
+    Celery 351.08
+    Peach 494.33
+    Butternut_Squash 650.32
+    Grapes 273.34
+    Watermelon 689.21
+    Ginger 332.04
+    Lime 412.19
+    Okra 463.68
+    Rosemary 211.36
+    Endive 815.60
+    Oregano 392.93
+    Papaya 748.41
+    Raspberry 525.88
+    Jackfruit 292.78
+    Kohlrabi 368.22
+    Banana 608.55
+    Cucumber 924.56
+    Currant 526.43
+    Essaouira 50345.79
+    Garlic 488.04
+    Cauliflower 478.29
+    Radish 420.17
+    Lime 222.15
+    Parsnip 490.06
+    Thyme 503.51
+    Chard 825.91
+    Eggplant 394.14
+    Turnip 674.53
+    Rosemary 477.27
+    Sage 716.75
+    Grapes 562.11
+    Acorn_Squash 1378.40
+    Salsify 503.63
+    Clementine 521.65
+    Mango 384.36
+    Sweet_Potato 315.61
+    Zucchini 331.62
+    Ginger 564.70
+    Currant 430.33
+    Strawberry 672.20
+    Pineapple 942.24
+    Onion 366.28
+    Pomegranate 998.64
+    Coconut 1103.77
+    Cantaloupe 919.35
+    Honeydew 1289.27
+    Beet 317.28
+    Artichoke 793.23
+    Jackfruit 421.99
+    Oregano 533.31
+    Rhubarb 469.05
+    Dragon_Fruit 293.90
+    Butternut_Squash 423.16
+    Persimmon 317.53
+    Raspberry 459.77
+    Lemon 967.49
+    Blueberry 595.58
+    Cilantro 399.14
+    Starfruit 549.64
+    Watercress 343.29
+    Tomato 311.06
+    Cactus_Pear 351.03
+    Cherry 486.64
+    Pumpkin 402.49
+    Banana 473.90
+    Blackberry 466.46
+    Rutabaga 289.12
+    Plum 582.86
+    Watermelon 205.84
+    Mint 555.61
+    Plantain 850.42
+    Guava 324.15
+    Peach 695.63
+    Collard_Greens 248.73
+    Asparagus 671.15
+    Okra 362.63
+    Kohlrabi 411.20
+    Kale 382.04
+    Cucumber 685.21
+    Yam 336.96
+    Basil 291.04
+    Bok_Choy 394.97
+    Papaya 364.60
+    Cranberry 1262.28
+    Peas 528.59
+    Pear 930.62
+    Cabbage 717.11
+    Goji_Berry 396.51
+    Endive 367.47
+    Nectarine 451.77
+    Grapefruit 487.24
+    Fig 771.69
+    Dill 575.06
+    Celery 866.70
+    Carrot 429.09
+    Potato 215.51
+    Broccoli 870.75
+    Brussels_Sprouts 342.95
+    Apple 352.66
+    Passion_Fruit 519.81
+    Squash_Blossom 471.54
+    Jicama 545.90
+    Bell_Pepper 543.41
+    Spinach 591.12
+    Avocado 441.10
+    Date 570.04
+    Kiwi 230.88
+    Orange 592.12
+    Green_Beans 582.08
+    Apricot 302.00
+    Lettuce 497.70
+    Kiwano 129.31
+    Parsley 759.70
+    Bir_Anzerane 48298.65
+    Grapes 539.23
+    Pineapple 470.46
+    Carrot 536.24
+    Cilantro 875.66
+    Cucumber 612.80
+    Pumpkin 474.06
+    Currant 273.82
+    Chard 991.55
+    Nectarine 363.61
+    Date 390.33
+    Kale 938.89
+    Sweet_Potato 511.34
+    Basil 368.55
+    Jicama 539.00
+    Bell_Pepper 772.46
+    Cantaloupe 960.29
+    Yam 366.36
+    Honeydew 1119.70
+    Cabbage 331.93
+    Banana 335.77
+    Collard_Greens 367.82
+    Mango 379.43
+    Radish 577.42
+    Dragon_Fruit 723.78
+    Orange 454.48
+    Blackberry 803.91
+    Squash_Blossom 444.98
+    Endive 294.29
+    Kohlrabi 342.98
+    Cherry 725.64
+    Clementine 548.21
+    Pear 566.83
+    Brussels_Sprouts 325.41
+    Jackfruit 304.40
+    Ginger 708.17
+    Guava 305.26
+    Garlic 517.67
+    Apricot 394.45
+    Persimmon 263.03
+    Lettuce 309.84
+    Kiwi 421.29
+    Rutabaga 311.72
+    Plantain 449.42
+    Coconut 977.60
+    Passion_Fruit 271.42
+    Cranberry 886.86
+    Salsify 549.28
+    Onion 236.13
+    Cactus_Pear 464.27
+    Pomegranate 843.65
+    Parsley 376.71
+    Kiwano 491.02
+    Zucchini 464.93
+    Broccoli 338.53
+    Fig 317.97
+    Green_Beans 381.22
+    Rhubarb 266.85
+    Plum 116.94
+    Okra 534.80
+    Raspberry 491.79
+    Rosemary 402.76
+    Parsnip 675.20
+    Beet 406.49
+    Oregano 419.79
+    Blueberry 853.54
+    Potato 517.40
+    Artichoke 1206.43
+    Tomato 592.67
+    Eggplant 334.04
+    Sage 560.69
+    Strawberry 689.19
+    Watercress 574.39
+    Asparagus 732.76
+    Starfruit 384.48
+    Turnip 739.97
+    Cauliflower 285.43
+    Thyme 513.68
+    Lemon 505.29
+    Celery 575.93
+    Acorn_Squash 236.53
+    Mint 326.96
+    Butternut_Squash 453.90
+    Peas 485.39
+    Goji_Berry 556.45
+    Watermelon 543.14
+    Avocado 986.43
+    Grapefruit 596.79
+    Lime 295.10
+    Spinach 251.79
+    Papaya 603.73
+    Dill 537.72
+    Apple 289.82
+    Bok_Choy 395.62
+    Peach 446.70
+    Dakhla 50064.89
+    Brussels_Sprouts 722.64
+    Garlic 296.01
+    Parsnip 713.40
+    Acorn_Squash 414.98
+    Mint 230.45
+    Apricot 385.02
+    Lettuce 312.92
+    Cactus_Pear 428.68
+    Watermelon 458.45
+    Grapefruit 524.29
+    Sweet_Potato 565.12
+    Dragon_Fruit 518.21
+    Starfruit 265.01
+    Bok_Choy 424.59
+    Broccoli 325.31
+    Plantain 687.15
+    Cucumber 582.72
+    Strawberry 251.33
+    Celery 554.80
+    Date 444.99
+    Rutabaga 792.86
+    Turnip 923.52
+    Blueberry 574.87
+    Oregano 385.55
+    Raspberry 665.21
+    Jackfruit 263.08
+    Cherry 549.35
+    Basil 138.73
+    Onion 545.08
+    Green_Beans 495.02
+    Kohlrabi 723.34
+    Coconut 827.20
+    Carrot 745.88
+    Eggplant 801.28
+    Jicama 406.54
+    Honeydew 1226.53
+    Blackberry 445.63
+    Rosemary 484.83
+    Cauliflower 500.09
+    Guava 720.82
+    Collard_Greens 563.48
+    Currant 487.58
+    Cilantro 563.49
+    Banana 660.31
+    Persimmon 424.95
+    Orange 327.31
+    Fig 704.47
+    Dill 303.01
+    Peas 154.82
+    Thyme 508.84
+    Plum 491.44
+    Nectarine 488.92
+    Rhubarb 462.82
+    Tomato 232.58
+    Pomegranate 708.58
+    Cantaloupe 1006.71
+    Squash_Blossom 228.01
+    Goji_Berry 435.54
+    Okra 605.69
+    Asparagus 637.66
+    Parsley 359.36
+    Zucchini 548.49
+    Yam 549.57
+    Avocado 330.09
+    Grapes 710.66
+    Cabbage 519.70
+    Mango 472.52
+    Butternut_Squash 285.88
+    Peach 718.25
+    Kiwano 584.77
+    Kiwi 739.20
+    Pear 488.13
+    Beet 605.11
+    Clementine 410.13
+    Pumpkin 790.39
+    Sage 1136.97
+    Potato 237.98
+    Lime 436.22
+    Apple 293.60
+    Papaya 330.59
+    Bell_Pepper 897.89
+    Kale 464.42
+    Spinach 150.89
+    Lemon 709.50
+    Cranberry 912.37
+    Pineapple 595.78
+    Passion_Fruit 499.90
+    Chard 450.27
+    Artichoke 421.41
+    Endive 847.10
+    Salsify 732.07
+    Radish 484.81
+    Watercress 595.86
+    Ginger 437.32
+    Midar 49347.56
+    Peas 796.76
+    Garlic 860.33
+    Coconut 1212.99
+    Cherry 608.90
+    Butternut_Squash 619.81
+    Nectarine 370.01
+    Lime 457.51
+    Avocado 342.56
+    Papaya 557.69
+    Artichoke 1213.71
+    Passion_Fruit 368.44
+    Peach 789.95
+    Jicama 232.75
+    Lemon 581.75
+    Persimmon 578.80
+    Goji_Berry 729.65
+    Cilantro 551.85
+    Turnip 789.60
+    Apple 161.30
+    Brussels_Sprouts 215.59
+    Cucumber 191.61
+    Rutabaga 392.87
+    Fig 541.15
+    Oregano 796.07
+    Grapes 302.80
+    Carrot 520.17
+    Potato 786.65
+    Bell_Pepper 262.02
+    Thyme 399.71
+    Eggplant 523.02
+    Parsley 425.31
+    Pear 484.99
+    Kohlrabi 388.56
+    Currant 552.69
+    Guava 196.90
+    Okra 749.86
+    Orange 588.42
+    Cabbage 324.08
+    Sweet_Potato 59.56
+    Cauliflower 348.50
+    Clementine 384.21
+    Cactus_Pear 787.54
+    Lettuce 719.53
+    Beet 430.08
+    Rhubarb 366.30
+    Endive 217.59
+    Blackberry 615.54
+    Banana 564.81
+    Zucchini 702.77
+    Asparagus 827.31
+    Plum 661.54
+    Starfruit 674.85
+    Cranberry 641.71
+    Parsnip 396.62
+    Date 479.49
+    Collard_Greens 517.33
+    Kale 310.39
+    Broccoli 752.07
+    Sage 495.48
+    Kiwi 530.93
+    Dragon_Fruit 303.14
+    Mango 199.49
+    Watermelon 252.60
+    Onion 461.82
+    Acorn_Squash 403.73
+    Plantain 584.21
+    Ginger 537.69
+    Basil 772.81
+    Pineapple 287.04
+    Green_Beans 434.46
+    Watercress 837.59
+    Grapefruit 384.75
+    Jackfruit 528.51
+    Bok_Choy 226.78
+    Apricot 680.91
+    Squash_Blossom 872.93
+    Pumpkin 484.38
+    Yam 886.95
+    Tomato 399.14
+    Rosemary 246.56
+    Cantaloupe 603.53
+    Spinach 302.80
+    Mint 653.13
+    Pomegranate 833.09
+    Celery 215.36
+    Chard 526.72
+    Strawberry 380.83
+    Blueberry 603.42
+    Raspberry 696.31
+    Dill 576.97
+    Salsify 349.67
+    Kiwano 576.94
+    Honeydew 927.54
+    Radish 364.78
+    Kalaat_MGouna 48583.87
+    Papaya 700.33
+    Kiwano 494.18
+    Parsley 291.21
+    Potato 576.42
+    Artichoke 822.94
+    Grapes 370.40
+    Fig 515.63
+    Endive 300.10
+    Kohlrabi 581.54
+    Carrot 441.03
+    Bell_Pepper 563.81
+    Sweet_Potato 221.33
+    Goji_Berry 976.72
+    Kiwi 251.78
+    Peach 355.71
+    Jackfruit 362.47
+    Bok_Choy 451.61
+    Collard_Greens 605.30
+    Watermelon 654.36
+    Rosemary 81.18
+    Brussels_Sprouts 296.89
+    Celery 792.17
+    Thyme 584.15
+    Passion_Fruit 305.06
+    Onion 609.07
+    Cantaloupe 765.59
+    Rhubarb 569.93
+    Coconut 700.44
+    Pumpkin 624.87
+    Spinach 689.50
+    Rutabaga 650.81
+    Beet 384.11
+    Orange 512.87
+    Plantain 536.55
+    Mint 483.86
+    Grapefruit 238.13
+    Apricot 617.89
+    Pomegranate 537.27
+    Raspberry 772.35
+    Ginger 528.77
+    Tomato 463.51
+    Starfruit 586.03
+    Nectarine 386.12
+    Cucumber 442.85
+    Strawberry 318.78
+    Pineapple 489.61
+    Cherry 153.16
+    Lemon 515.09
+    Guava 718.90
+    Watercress 538.92
+    Asparagus 635.16
+    Radish 411.54
+    Mango 436.62
+    Turnip 710.66
+    Yam 283.68
+    Cilantro 184.22
+    Basil 455.18
+    Butternut_Squash 524.66
+    Dragon_Fruit 829.03
+    Sage 455.62
+    Salsify 590.12
+    Pear 638.99
+    Eggplant 504.58
+    Cauliflower 454.58
+    Blackberry 377.02
+    Dill 576.01
+    Lime 355.32
+    Garlic 288.85
+    Currant 708.38
+    Acorn_Squash 298.05
+    Cactus_Pear 659.50
+    Date 847.87
+    Banana 603.01
+    Broccoli 448.74
+    Lettuce 546.89
+    Clementine 489.30
+    Green_Beans 472.32
+    Oregano 717.71
+    Parsnip 343.39
+    Peas 654.87
+    Zucchini 740.33
+    Okra 337.84
+    Chard 381.46
+    Cranberry 886.26
+    Jicama 221.02
+    Plum 622.91
+    Blueberry 802.86
+    Cabbage 462.93
+    Avocado 477.42
+    Squash_Blossom 211.84
+    Apple 408.63
+    Kale 787.65
+    Honeydew 899.09
+    Persimmon 410.46
+    Casablanca 45534.98
+    Cactus_Pear 554.27
+    Chard 660.30
+    Peas 724.22
+    Cilantro 567.60
+    Collard_Greens 534.55
+    Pear 722.86
+    Strawberry 761.64
+    Kiwano 435.20
+    Grapes 283.14
+    Sweet_Potato 389.14
+    Spinach 204.90
+    Currant 354.07
+    Goji_Berry 170.00
+    Broccoli 582.16
+    Kiwi 400.13
+    Passion_Fruit 435.22
+    Acorn_Squash 499.31
+    Tomato 379.62
+    Rutabaga 248.49
+    Banana 649.06
+    Mint 393.37
+    Parsley 607.32
+    Jackfruit 788.44
+    Turnip 709.42
+    Bell_Pepper 442.88
+    Starfruit 183.87
+    Oregano 458.59
+    Cantaloupe 927.20
+    Cabbage 295.23
+    Apricot 501.00
+    Dill 647.91
+    Jicama 119.21
+    Cherry 324.62
+    Papaya 309.33
+    Pineapple 481.80
+    Kohlrabi 531.09
+    Apple 731.34
+    Zucchini 906.30
+    Date 291.60
+    Avocado 71.65
+    Artichoke 811.08
+    Coconut 898.55
+    Beet 440.94
+    Cauliflower 104.71
+    Clementine 348.73
+    Asparagus 466.19
+    Potato 593.75
+    Ginger 526.33
+    Peach 467.95
+    Sage 434.74
+    Endive 411.35
+    Raspberry 393.98
+    Blackberry 776.82
+    Dragon_Fruit 567.81
+    Blueberry 453.58
+    Brussels_Sprouts 477.36
+    Pumpkin 409.21
+    Pomegranate 496.11
+    Eggplant 493.43
+    Salsify 534.29
+    Watercress 548.11
+    Garlic 347.96
+    Radish 350.25
+    Grapefruit 550.50
+    Plum 631.69
+    Green_Beans 737.79
+    Lime 398.39
+    Watermelon 75.96
+    Rosemary 698.17
+    Cucumber 484.70
+    Butternut_Squash 336.56
+    Rhubarb 299.69
+    Persimmon 471.93
+    Nectarine 510.99
+    Guava 538.62
+    Mango 652.44
+    Lemon 601.35
+    Plantain 510.14
+    Celery 176.72
+    Parsnip 391.51
+    Yam 395.42
+    Orange 245.94
+    Lettuce 439.33
+    Onion 309.84
+    Thyme 524.53
+    Carrot 702.73
+    Basil 528.48
+    Bok_Choy 579.55
+    Cranberry 789.22
+    Fig 372.57
+    Kale 429.15
+    Okra 216.40
+    Squash_Blossom 491.45
+    Honeydew 811.94
+    Guercif 50582.05
+    Sage 630.04
+    Starfruit 152.05
+    Passion_Fruit 359.60
+    Ginger 456.58
+    Turnip 390.60
+    Grapes 210.59
+    Rhubarb 411.43
+    Mango 503.27
+    Rosemary 460.87
+    Cranberry 887.15
+    Zucchini 853.49
+    Lemon 831.50
+    Squash_Blossom 653.70
+    Broccoli 492.31
+    Onion 173.69
+    Grapefruit 251.66
+    Brussels_Sprouts 288.08
+    Watermelon 759.04
+    Apricot 484.32
+    Jicama 680.84
+    Sweet_Potato 131.41
+    Lettuce 216.21
+    Oregano 779.48
+    Pineapple 596.94
+    Kohlrabi 590.20
+    Parsnip 331.69
+    Coconut 1285.05
+    Potato 437.17
+    Radish 657.22
+    Clementine 661.50
+    Kiwi 419.95
+    Cactus_Pear 769.05
+    Kiwano 661.68
+    Blueberry 477.49
+    Watercress 220.27
+    Chard 165.21
+    Orange 619.16
+    Lime 793.45
+    Dragon_Fruit 419.55
+    Peas 886.19
+    Cabbage 800.33
+    Cherry 709.17
+    Butternut_Squash 340.70
+    Peach 520.38
+    Spinach 303.30
+    Tomato 250.63
+    Apple 532.57
+    Honeydew 1035.59
+    Artichoke 1274.78
+    Beet 700.75
+    Jackfruit 278.30
+    Asparagus 352.02
+    Cantaloupe 621.53
+    Endive 481.86
+    Celery 424.37
+    Blackberry 758.39
+    Kale 694.04
+    Avocado 504.38
+    Currant 335.47
+    Yam 568.97
+    Papaya 905.92
+    Collard_Greens 427.80
+    Bok_Choy 636.57
+    Dill 629.40
+    Acorn_Squash 741.99
+    Raspberry 395.16
+    Carrot 313.84
+    Guava 876.06
+    Eggplant 438.38
+    Pumpkin 621.92
+    Cucumber 317.91
+    Pomegranate 1389.85
+    Date 250.33
+    Plum 209.33
+    Fig 635.62
+    Plantain 508.27
+    Basil 620.62
+    Nectarine 659.77
+    Thyme 495.01
+    Strawberry 322.62
+    Rutabaga 501.83
+    Persimmon 381.22
+    Salsify 391.71
+    Pear 500.05
+    Bell_Pepper 457.21
+    Green_Beans 747.40
+    Goji_Berry 466.47
+    Banana 460.59
+    Garlic 359.39
+    Okra 561.75
+    Parsley 869.26
+    Mint 405.65
+    Cauliflower 167.73
+    Cilantro 378.21
+    Ksar_El_Kebir 49647.23
+    Carrot 492.64
+    Cauliflower 523.93
+    Date 521.22
+    Celery 800.77
+    Dragon_Fruit 667.26
+    Broccoli 748.69
+    Rosemary 185.92
+    Chard 225.74
+    Pineapple 428.52
+    Currant 843.89
+    Raspberry 525.66
+    Apricot 657.02
+    Parsnip 541.96
+    Pumpkin 429.50
+    Watermelon 743.72
+    Pear 359.42
+    Dill 122.69
+    Starfruit 380.36
+    Grapes 555.37
+    Fig 237.99
+    Cantaloupe 958.55
+    Yam 230.36
+    Lemon 520.55
+    Oregano 693.24
+    Cilantro 418.16
+    Blueberry 458.28
+    Rhubarb 408.53
+    Radish 454.97
+    Jackfruit 651.87
+    Parsley 594.29
+    Pomegranate 927.77
+    Nectarine 454.79
+    Rutabaga 428.57
+    Kale 531.23
+    Ginger 623.55
+    Tomato 547.88
+    Collard_Greens 595.29
+    Avocado 243.97
+    Goji_Berry 403.91
+    Green_Beans 631.55
+    Turnip 497.34
+    Okra 588.53
+    Peas 487.58
+    Potato 522.77
+    Banana 486.73
+    Cranberry 684.93
+    Bell_Pepper 498.09
+    Mango 407.13
+    Eggplant 415.51
+    Beet 408.77
+    Kiwi 599.95
+    Lime 619.01
+    Honeydew 1059.22
+    Clementine 519.54
+    Thyme 668.45
+    Mint 712.62
+    Watercress 599.58
+    Strawberry 623.94
+    Kohlrabi 394.23
+    Cucumber 407.72
+    Orange 329.10
+    Peach 404.01
+    Cherry 360.39
+    Asparagus 1088.05
+    Blackberry 596.02
+    Squash_Blossom 442.57
+    Grapefruit 479.84
+    Apple 660.24
+    Acorn_Squash 367.55
+    Cabbage 654.92
+    Butternut_Squash 364.48
+    Bok_Choy 252.80
+    Coconut 965.46
+    Brussels_Sprouts 556.07
+    Kiwano 861.24
+    Passion_Fruit 413.29
+    Jicama 425.28
+    Plantain 435.88
+    Sage 458.63
+    Onion 741.31
+    Salsify 435.92
+    Plum 439.39
+    Guava 421.92
+    Cactus_Pear 542.23
+    Sweet_Potato 728.38
+    Spinach 511.08
+    Persimmon 277.72
+    Lettuce 503.92
+    Artichoke 1030.01
+    Garlic 646.14
+    Zucchini 72.76
+    Basil 237.75
+    Endive 509.90
+    Papaya 461.76
+    Tiznit 49507.93
+    Acorn_Squash 541.37
+    Broccoli 478.53
+    Green_Beans 546.76
+    Rosemary 482.13
+    Blackberry 468.71
+    Rhubarb 436.61
+    Butternut_Squash 664.19
+    Mint 625.68
+    Honeydew 1172.99
+    Starfruit 509.28
+    Collard_Greens 264.48
+    Radish 314.61
+    Pomegranate 992.59
+    Onion 443.59
+    Basil 701.25
+    Banana 430.68
+    Oregano 356.84
+    Clementine 478.69
+    Yam 506.60
+    Kohlrabi 378.52
+    Zucchini 477.08
+    Kiwi 532.36
+    Strawberry 731.65
+    Cranberry 1172.61
+    Papaya 338.96
+    Pear 541.35
+    Endive 117.92
+    Parsley 434.24
+    Chard 519.41
+    Sage 662.05
+    Peach 509.54
+    Squash_Blossom 523.96
+    Cucumber 502.34
+    Beet 345.70
+    Plum 768.87
+    Lemon 358.20
+    Blueberry 561.39
+    Peas 433.37
+    Plantain 619.00
+    Spinach 792.21
+    Pineapple 411.64
+    Cilantro 452.78
+    Rutabaga 415.12
+    Eggplant 661.35
+    Tomato 236.51
+    Watercress 535.50
+    Dill 201.31
+    Asparagus 284.93
+    Ginger 634.39
+    Thyme 566.40
+    Coconut 960.20
+    Jackfruit 975.30
+    Grapes 473.94
+    Bok_Choy 518.88
+    Parsnip 265.54
+    Date 497.11
+    Cherry 533.26
+    Salsify 695.34
+    Bell_Pepper 692.31
+    Guava 393.44
+    Apple 279.80
+    Okra 480.86
+    Avocado 310.41
+    Currant 404.53
+    Celery 422.65
+    Potato 316.14
+    Brussels_Sprouts 576.22
+    Carrot 470.97
+    Cactus_Pear 501.74
+    Lettuce 635.08
+    Sweet_Potato 739.30
+    Jicama 263.61
+    Persimmon 289.10
+    Dragon_Fruit 356.46
+    Kiwano 506.32
+    Nectarine 489.51
+    Cantaloupe 751.16
+    Pumpkin 815.65
+    Passion_Fruit 1139.46
+    Grapefruit 295.75
+    Cauliflower 593.93
+    Mango 616.52
+    Cabbage 411.44
+    Kale 354.16
+    Raspberry 681.60
+    Turnip 109.75
+    Watermelon 581.45
+    Orange 395.04
+    Artichoke 1096.64
+    Goji_Berry 379.63
+    Lime 558.90
+    Fig 459.36
+    Apricot 291.87
+    Garlic 791.36
+    Errachidia 51497.38
+    Jackfruit 531.06
+    Rhubarb 349.53
+    Bell_Pepper 408.78
+    Plantain 484.37
+    Sage 583.77
+    Celery 499.61
+    Rutabaga 684.66
+    Kiwi 527.75
+    Persimmon 648.82
+    Cabbage 407.72
+    Tomato 266.98
+    Cauliflower 303.77
+    Kohlrabi 557.46
+    Cantaloupe 1743.90
+    Butternut_Squash 439.39
+    Banana 599.40
+    Apricot 135.63
+    Artichoke 820.87
+    Plum 397.83
+    Cilantro 509.40
+    Brussels_Sprouts 585.98
+    Ginger 579.11
+    Carrot 250.48
+    Squash_Blossom 476.71
+    Okra 354.60
+    Goji_Berry 531.60
+    Endive 632.38
+    Salsify 813.77
+    Nectarine 556.06
+    Fig 247.80
+    Currant 689.80
+    Peas 355.67
+    Honeydew 1202.42
+    Passion_Fruit 463.41
+    Turnip 807.04
+    Papaya 733.77
+    Raspberry 404.40
+    Lime 157.93
+    Eggplant 816.98
+    Acorn_Squash 803.74
+    Blueberry 383.18
+    Dill 392.42
+    Asparagus 521.79
+    Watercress 675.19
+    Basil 423.61
+    Onion 476.36
+    Dragon_Fruit 701.46
+    Date 846.94
+    Cherry 483.23
+    Apple 562.29
+    Beet 482.70
+    Sweet_Potato 1148.42
+    Oregano 108.97
+    Watermelon 649.95
+    Strawberry 366.33
+    Radish 324.67
+    Jicama 226.27
+    Garlic 475.51
+    Mango 500.01
+    Cactus_Pear 322.39
+    Zucchini 347.09
+    Blackberry 625.22
+    Pineapple 463.41
+    Cranberry 791.63
+    Grapes 468.47
+    Parsnip 257.18
+    Lemon 241.38
+    Green_Beans 639.82
+    Avocado 854.63
+    Coconut 898.40
+    Peach 301.81
+    Starfruit 632.06
+    Grapefruit 309.64
+    Lettuce 567.32
+    Pumpkin 630.20
+    Clementine 328.16
+    Cucumber 771.85
+    Guava 751.95
+    Parsley 402.97
+    Yam 880.13
+    Rosemary 466.20
+    Collard_Greens 325.69
+    Broccoli 473.94
+    Thyme 929.34
+    Spinach 218.21
+    Pomegranate 1141.50
+    Pear 326.30
+    Orange 679.21
+    Mint 545.09
+    Kale 369.00
+    Potato 479.05
+    Chard 557.97
+    Bok_Choy 609.62
+    Kiwano 776.90
+    Laâyoune 50949.62
+    Dragon_Fruit 331.07
+    Radish 294.16
+    Spinach 512.73
+    Cucumber 196.41
+    Thyme 625.12
+    Cilantro 627.04
+    Basil 446.92
+    Turnip 428.75
+    Carrot 609.30
+    Plantain 647.56
+    Broccoli 688.75
+    Parsley 485.60
+    Orange 412.14
+    Cantaloupe 719.48
+    Grapes 617.32
+    Brussels_Sprouts 641.14
+    Currant 253.24
+    Cranberry 1373.54
+    Okra 494.23
+    Goji_Berry 343.90
+    Acorn_Squash 508.79
+    Zucchini 509.03
+    Parsnip 361.02
+    Green_Beans 486.92
+    Sweet_Potato 576.40
+    Chard 676.63
+    Cauliflower 640.62
+    Yam 198.22
+    Salsify 451.97
+    Artichoke 1720.85
+    Apple 717.03
+    Banana 545.48
+    Potato 553.71
+    Cabbage 338.59
+    Rosemary 385.80
+    Collard_Greens 420.27
+    Kiwi 398.11
+    Clementine 540.95
+    Blueberry 513.60
+    Jackfruit 687.66
+    Lime 530.59
+    Honeydew 1487.76
+    Strawberry 763.28
+    Cactus_Pear 477.23
+    Endive 306.29
+    Blackberry 711.70
+    Pineapple 478.43
+    Dill 731.03
+    Raspberry 607.13
+    Guava 301.42
+    Bell_Pepper 731.73
+    Watermelon 687.97
+    Garlic 492.92
+    Lemon 481.44
+    Squash_Blossom 651.50
+    Beet 235.51
+    Bok_Choy 661.19
+    Celery 815.87
+    Lettuce 757.13
+    Kohlrabi 352.59
+    Passion_Fruit 522.90
+    Pear 519.64
+    Plum 418.02
+    Watercress 430.08
+    Mint 320.94
+    Tomato 495.11
+    Rhubarb 305.31
+    Asparagus 571.87
+    Cherry 447.77
+    Eggplant 341.84
+    Mango 331.26
+    Avocado 406.08
+    Sage 359.97
+    Coconut 930.24
+    Peach 825.63
+    Starfruit 471.81
+    Fig 443.57
+    Papaya 280.39
+    Kale 486.16
+    Butternut_Squash 244.44
+    Jicama 307.69
+    Pumpkin 379.68
+    Nectarine 490.39
+    Kiwano 390.06
+    Rutabaga 598.30
+    Pomegranate 1252.39
+    Peas 1030.89
+    Apricot 541.24
+    Grapefruit 521.79
+    Date 346.39
+    Onion 611.02
+    Oregano 395.19
+    Persimmon 397.89
+    Ginger 290.91
+    Jerada 49787.36
+    Cilantro 496.96
+    Celery 615.30
+    Bok_Choy 659.33
+    Cherry 600.99
+    Banana 669.33
+    Collard_Greens 788.12
+    Jicama 407.70
+    Rosemary 455.88
+    Apricot 165.91
+    Dragon_Fruit 877.18
+    Passion_Fruit 643.39
+    Squash_Blossom 607.41
+    Sweet_Potato 583.92
+    Avocado 703.81
+    Kohlrabi 203.11
+    Persimmon 575.07
+    Beet 469.69
+    Starfruit 570.95
+    Lettuce 538.60
+    Pumpkin 202.58
+    Watercress 788.04
+    Cactus_Pear 505.85
+    Currant 535.74
+    Broccoli 601.61
+    Artichoke 1048.30
+    Mango 216.02
+    Kiwano 447.60
+    Spinach 654.58
+    Turnip 732.74
+    Acorn_Squash 361.60
+    Watermelon 539.74
+    Chard 513.99
+    Salsify 492.61
+    Lime 392.76
+    Blueberry 220.96
+    Clementine 311.14
+    Mint 557.95
+    Garlic 585.07
+    Thyme 430.20
+    Cantaloupe 1141.18
+    Parsnip 502.26
+    Sage 544.11
+    Butternut_Squash 535.00
+    Pineapple 550.22
+    Onion 404.31
+    Orange 656.52
+    Apple 614.63
+    Tomato 373.18
+    Plum 526.96
+    Bell_Pepper 615.87
+    Kiwi 55.11
+    Parsley 291.93
+    Blackberry 260.34
+    Pomegranate 1015.63
+    Asparagus 506.43
+    Lemon 462.25
+    Radish 350.91
+    Date 533.36
+    Dill 709.29
+    Grapefruit 508.52
+    Strawberry 895.08
+    Cabbage 475.53
+    Cranberry 986.47
+    Carrot 468.22
+    Ginger 469.02
+    Grapes 249.66
+    Nectarine 142.79
+    Guava 418.83
+    Raspberry 486.42
+    Potato 1053.85
+    Peas 421.82
+    Yam 563.91
+    Plantain 344.92
+    Goji_Berry 336.78
+    Okra 537.38
+    Fig 518.93
+    Basil 617.85
+    Green_Beans 253.32
+    Peach 603.59
+    Cauliflower 346.37
+    Coconut 1204.83
+    Jackfruit 221.91
+    Rhubarb 386.56
+    Oregano 612.03
+    Zucchini 447.35
+    Kale 529.17
+    Endive 552.62
+    Eggplant 306.25
+    Honeydew 975.28
+    Cucumber 543.36
+    Papaya 533.92
+    Brussels_Sprouts 766.55
+    Pear 160.93
+    Rutabaga 426.12
+    Souk_Larbaa 50341.03
+    Clementine 671.10
+    Thyme 653.42
+    Bell_Pepper 421.66
+    Banana 505.53
+    Cantaloupe 553.81
+    Currant 314.35
+    Cactus_Pear 609.10
+    Brussels_Sprouts 615.02
+    Orange 511.08
+    Turnip 499.05
+    Carrot 501.94
+    Guava 948.83
+    Artichoke 787.58
+    Jackfruit 619.96
+    Nectarine 574.24
+    Collard_Greens 379.31
+    Bok_Choy 503.41
+    Spinach 403.26
+    Acorn_Squash 436.19
+    Butternut_Squash 957.74
+    Date 463.13
+    Kiwano 481.36
+    Asparagus 351.30
+    Grapefruit 687.81
+    Salsify 381.93
+    Radish 656.99
+    Strawberry 372.53
+    Cilantro 755.78
+    Lemon 376.82
+    Plum 706.48
+    Lettuce 574.27
+    Parsnip 484.84
+    Broccoli 575.57
+    Oregano 366.48
+    Rhubarb 369.93
+    Apricot 350.60
+    Rutabaga 463.19
+    Avocado 539.62
+    Cauliflower 364.98
+    Zucchini 610.51
+    Okra 918.48
+    Garlic 342.65
+    Squash_Blossom 370.41
+    Cabbage 570.41
+    Grapes 549.69
+    Dill 465.82
+    Kiwi 578.92
+    Sage 270.61
+    Peach 468.39
+    Raspberry 623.53
+    Blueberry 186.09
+    Apple 493.98
+    Lime 547.00
+    Pomegranate 636.02
+    Cranberry 1611.37
+    Tomato 497.16
+    Fig 542.31
+    Pumpkin 397.49
+    Watermelon 597.21
+    Beet 531.18
+    Green_Beans 679.37
+    Pear 575.73
+    Plantain 163.00
+    Coconut 778.27
+    Mango 765.61
+    Pineapple 670.87
+    Kohlrabi 411.28
+    Rosemary 788.35
+    Cucumber 728.51
+    Cherry 289.12
+    Kale 909.52
+    Honeydew 1245.03
+    Dragon_Fruit 688.15
+    Watercress 669.54
+    Persimmon 372.24
+    Passion_Fruit 612.61
+    Blackberry 381.82
+    Celery 726.79
+    Parsley 354.26
+    Yam 549.21
+    Eggplant 234.11
+    Jicama 697.21
+    Ginger 353.06
+    Papaya 334.40
+    Chard 711.21
+    Onion 263.47
+    Basil 153.32
+    Peas 583.96
+    Starfruit 470.16
+    Potato 314.29
+    Mint 427.02
+    Endive 333.22
+    Sweet_Potato 313.50
+    Goji_Berry 193.40
+    Ahfir 48224.38
+    Okra 546.26
+    Orange 544.08
+    Plum 494.38
+    Celery 958.10
+    Cauliflower 654.32
+    Papaya 825.51
+    Onion 453.23
+    Watercress 344.29
+    Kiwano 273.39
+    Spinach 596.46
+    Lettuce 559.70
+    Nectarine 318.03
+    Apricot 543.30
+    Beet 563.35
+    Oregano 301.63
+    Kale 730.16
+    Starfruit 543.32
+    Kiwi 363.01
+    Artichoke 872.02
+    Grapefruit 565.34
+    Date 298.62
+    Brussels_Sprouts 304.98
+    Broccoli 643.39
+    Tomato 321.33
+    Salsify 641.19
+    Acorn_Squash 410.15
+    Cactus_Pear 427.04
+    Pineapple 596.54
+    Apple 544.25
+    Ginger 386.88
+    Jackfruit 404.31
+    Basil 170.80
+    Blueberry 454.12
+    Peas 450.61
+    Turnip 565.42
+    Garlic 371.56
+    Avocado 284.54
+    Endive 230.14
+    Eggplant 618.88
+    Yam 280.74
+    Cantaloupe 1381.14
+    Squash_Blossom 779.81
+    Lemon 375.68
+    Persimmon 623.10
+    Lime 245.10
+    Goji_Berry 434.83
+    Blackberry 602.61
+    Pumpkin 521.47
+    Raspberry 782.23
+    Rosemary 410.94
+    Coconut 932.54
+    Thyme 496.05
+    Cherry 562.94
+    Zucchini 526.59
+    Sweet_Potato 756.28
+    Kohlrabi 442.96
+    Sage 536.94
+    Cilantro 550.07
+    Clementine 433.46
+    Cabbage 306.74
+    Dragon_Fruit 286.41
+    Guava 413.33
+    Cucumber 625.58
+    Mango 248.84
+    Potato 461.11
+    Parsley 832.82
+    Strawberry 169.01
+    Pear 605.38
+    Rhubarb 280.46
+    Carrot 464.51
+    Butternut_Squash 267.31
+    Grapes 306.16
+    Dill 279.32
+    Radish 613.88
+    Banana 407.69
+    Currant 203.52
+    Rutabaga 681.09
+    Honeydew 1565.83
+    Asparagus 555.23
+    Pomegranate 976.22
+    Collard_Greens 247.90
+    Chard 451.52
+    Peach 1037.79
+    Cranberry 739.79
+    Parsnip 387.04
+    Fig 229.39
+    Bell_Pepper 472.00
+    Mint 969.28
+    Watermelon 206.19
+    Green_Beans 489.49
+    Plantain 178.74
+    Bok_Choy 742.91
+    Passion_Fruit 443.75
+    Jicama 228.04
+    Midelt 48849.72
+    Parsley 453.56
+    Honeydew 1470.60
+    Plantain 313.50
+    Brussels_Sprouts 410.68
+    Dill 479.42
+    Garlic 339.57
+    Papaya 479.55
+    Coconut 918.57
+    Currant 433.02
+    Okra 473.27
+    Bell_Pepper 733.77
+    Lettuce 483.37
+    Sage 254.32
+    Rhubarb 707.17
+    Tomato 346.85
+    Raspberry 363.82
+    Watercress 680.88
+    Kohlrabi 664.88
+    Banana 679.10
+    Cantaloupe 933.77
+    Clementine 328.09
+    Squash_Blossom 451.36
+    Spinach 603.84
+    Cucumber 673.46
+    Rosemary 389.81
+    Basil 690.92
+    Yam 476.91
+    Thyme 531.37
+    Kiwano 329.61
+    Peas 736.99
+    Beet 357.68
+    Eggplant 189.39
+    Cherry 401.40
+    Lime 721.43
+    Blackberry 586.12
+    Sweet_Potato 457.50
+    Nectarine 425.32
+    Blueberry 463.19
+    Guava 457.71
+    Jicama 533.66
+    Pear 898.16
+    Orange 269.05
+    Parsnip 237.44
+    Turnip 598.74
+    Fig 532.52
+    Dragon_Fruit 542.18
+    Oregano 492.80
+    Persimmon 334.09
+    Endive 530.77
+    Lemon 826.73
+    Rutabaga 389.42
+    Broccoli 502.29
+    Zucchini 459.56
+    Carrot 439.69
+    Onion 560.13
+    Acorn_Squash 852.61
+    Cranberry 1014.83
+    Mango 488.62
+    Cauliflower 349.12
+    Asparagus 516.77
+    Avocado 598.49
+    Peach 186.12
+    Bok_Choy 471.72
+    Jackfruit 662.09
+    Butternut_Squash 477.85
+    Mint 417.59
+    Green_Beans 323.73
+    Chard 828.04
+    Pumpkin 654.45
+    Salsify 836.98
+    Potato 173.68
+    Kale 239.62
+    Cabbage 396.20
+    Radish 623.78
+    Grapefruit 735.12
+    Passion_Fruit 342.02
+    Goji_Berry 732.48
+    Strawberry 312.54
+    Grapes 439.58
+    Kiwi 536.55
+    Ginger 511.71
+    Cilantro 715.02
+    Plum 378.49
+    Pomegranate 899.83
+    Collard_Greens 468.13
+    Date 172.08
+    Apple 484.94
+    Cactus_Pear 409.01
+    Pineapple 227.19
+    Celery 417.61
+    Apricot 677.98
+    Watermelon 438.73
+    Artichoke 799.42
+    Saidia 50655.58
+    Coconut 1168.94
+    Cranberry 816.04
+    Orange 715.52
+    Dragon_Fruit 516.29
+    Pomegranate 1325.78
+    Rutabaga 440.02
+    Broccoli 489.16
+    Beet 603.63
+    Kale 355.36
+    Sage 300.99
+    Jackfruit 534.87
+    Yam 343.59
+    Nectarine 452.24
+    Date 386.00
+    Sweet_Potato 469.20
+    Garlic 746.51
+    Squash_Blossom 403.14
+    Bok_Choy 392.53
+    Raspberry 634.26
+    Green_Beans 660.57
+    Ginger 968.97
+    Cabbage 472.40
+    Radish 769.21
+    Peach 137.54
+    Pumpkin 839.01
+    Okra 279.86
+    Bell_Pepper 674.34
+    Dill 589.85
+    Acorn_Squash 282.74
+    Endive 639.81
+    Starfruit 498.57
+    Fig 353.10
+    Blackberry 485.74
+    Collard_Greens 374.27
+    Lettuce 845.90
+    Pineapple 711.35
+    Mango 851.58
+    Chard 592.34
+    Avocado 371.98
+    Turnip 750.96
+    Apple 845.82
+    Lemon 454.47
+    Tomato 559.17
+    Eggplant 415.42
+    Grapefruit 609.76
+    Cilantro 485.11
+    Kiwano 585.21
+    Jicama 696.96
+    Parsnip 930.17
+    Strawberry 857.65
+    Onion 619.81
+    Plantain 261.94
+    Plum 214.51
+    Grapes 409.75
+    Clementine 265.87
+    Oregano 494.39
+    Thyme 309.98
+    Cactus_Pear 550.09
+    Spinach 349.14
+    Potato 659.35
+    Currant 359.71
+    Mint 256.57
+    Honeydew 548.43
+    Cauliflower 249.30
+    Rosemary 425.30
+    Watermelon 503.32
+    Butternut_Squash 465.94
+    Pear 714.44
+    Brussels_Sprouts 605.26
+    Zucchini 453.41
+    Cucumber 673.82
+    Celery 642.78
+    Carrot 638.41
+    Artichoke 567.89
+    Papaya 230.69
+    Basil 406.44
+    Guava 538.50
+    Parsley 667.81
+    Persimmon 586.43
+    Goji_Berry 850.38
+    Kohlrabi 451.04
+    Rhubarb 478.13
+    Asparagus 577.56
+    Blueberry 667.93
+    Cantaloupe 617.97
+    Apricot 579.65
+    Kiwi 443.21
+    Peas 4.98
+    Salsify 423.93
+    Lime 427.24
+    Banana 352.04
+    Watercress 456.70
+    Cherry 375.48
+    Passion_Fruit 596.16
+    Ouarzazate 50553.68
+    Garlic 463.83
+    Nectarine 366.92
+    Cantaloupe 1221.00
+    Thyme 465.87
+    Apple 600.31
+    Currant 615.68
+    Green_Beans 594.44
+    Passion_Fruit 631.87
+    Honeydew 1017.14
+    Zucchini 511.50
+    Cauliflower 736.04
+    Sweet_Potato 335.88
+    Broccoli 586.30
+    Peas 484.39
+    Acorn_Squash 664.40
+    Apricot 839.38
+    Grapefruit 357.07
+    Brussels_Sprouts 674.40
+    Spinach 769.03
+    Cilantro 349.83
+    Potato 690.57
+    Eggplant 501.67
+    Turnip 698.56
+    Guava 485.21
+    Date 678.64
+    Pear 276.89
+    Blueberry 517.41
+    Cabbage 460.80
+    Rhubarb 320.99
+    Papaya 331.59
+    Plantain 371.61
+    Tomato 767.17
+    Jackfruit 338.74
+    Rutabaga 381.56
+    Cucumber 730.45
+    Kiwano 604.01
+    Parsley 485.02
+    Mango 643.74
+    Bok_Choy 332.04
+    Cactus_Pear 291.10
+    Avocado 236.68
+    Kiwi 925.45
+    Plum 754.55
+    Orange 980.96
+    Basil 456.62
+    Celery 550.46
+    Grapes 503.29
+    Salsify 568.61
+    Artichoke 949.02
+    Parsnip 378.89
+    Clementine 741.62
+    Collard_Greens 655.91
+    Rosemary 190.05
+    Lime 568.14
+    Blackberry 688.77
+    Banana 392.04
+    Carrot 365.18
+    Mint 284.86
+    Dill 447.98
+    Watercress 313.79
+    Strawberry 648.93
+    Pomegranate 1392.50
+    Butternut_Squash 526.93
+    Cranberry 768.71
+    Peach 556.84
+    Coconut 842.77
+    Dragon_Fruit 381.51
+    Raspberry 564.09
+    Fig 741.98
+    Endive 658.85
+    Sage 469.31
+    Goji_Berry 537.28
+    Beet 357.45
+    Lettuce 69.73
+    Squash_Blossom 517.94
+    Starfruit 249.80
+    Onion 556.05
+    Okra 448.02
+    Jicama 176.86
+    Persimmon 326.37
+    Asparagus 204.72
+    Oregano 432.44
+    Watermelon 584.99
+    Lemon 493.05
+    Kale 407.07
+    Cherry 381.34
+    Chard 344.78
+    Radish 412.82
+    Ginger 676.72
+    Pumpkin 466.96
+    Pineapple 544.75
+    Bell_Pepper 399.38
+    Kohlrabi 373.03
+    Yam 893.79
+    Boulemane 50617.76
+    Strawberry 598.01
+    Okra 471.36
+    Green_Beans 541.22
+    Banana 756.59
+    Cauliflower 327.82
+    Brussels_Sprouts 337.78
+    Acorn_Squash 263.32
+    Pear 433.81
+    Squash_Blossom 615.20
+    Cabbage 388.30
+    Blackberry 353.73
+    Cranberry 905.82
+    Plantain 664.76
+    Passion_Fruit 521.54
+    Blueberry 388.88
+    Orange 461.21
+    Apple 449.33
+    Pumpkin 1054.79
+    Parsnip 414.64
+    Butternut_Squash 438.75
+    Dragon_Fruit 478.33
+    Ginger 351.38
+    Peach 498.30
+    Avocado 692.83
+    Carrot 621.86
+    Potato 264.05
+    Dill 419.33
+    Lettuce 234.15
+    Nectarine 297.97
+    Cantaloupe 1097.90
+    Jackfruit 935.36
+    Bell_Pepper 391.49
+    Yam 580.73
+    Endive 581.02
+    Bok_Choy 796.38
+    Mango 624.31
+    Rutabaga 537.08
+    Fig 338.25
+    Raspberry 463.79
+    Honeydew 1036.57
+    Thyme 536.52
+    Plum 706.68
+    Watercress 189.27
+    Rhubarb 583.39
+    Onion 555.16
+    Chard 278.41
+    Turnip 318.83
+    Parsley 491.37
+    Pineapple 488.29
+    Pomegranate 971.79
+    Currant 922.32
+    Starfruit 1005.34
+    Kiwi 721.99
+    Oregano 257.99
+    Sweet_Potato 427.14
+    Persimmon 487.97
+    Kiwano 999.92
+    Basil 460.94
+    Coconut 1065.89
+    Artichoke 723.91
+    Jicama 541.69
+    Asparagus 621.99
+    Mint 548.06
+    Broccoli 414.49
+    Rosemary 261.97
+    Clementine 717.06
+    Sage 499.77
+    Eggplant 367.69
+    Guava 692.28
+    Spinach 599.78
+    Date 425.98
+    Celery 714.09
+    Apricot 424.84
+    Beet 350.77
+    Garlic 608.02
+    Kohlrabi 647.93
+    Goji_Berry 872.58
+    Zucchini 269.57
+    Radish 543.73
+    Cucumber 219.80
+    Lemon 309.43
+    Grapefruit 703.35
+    Peas 482.32
+    Collard_Greens 556.06
+    Grapes 342.27
+    Salsify 599.95
+    Kale 473.84
+    Tomato 743.74
+    Papaya 325.58
+    Cherry 454.27
+    Cilantro 370.33
+    Watermelon 707.05
+    Cactus_Pear 270.82
+    Lime 115.60
+    Azrou 52243.32
+    Thyme 864.11
+    Cantaloupe 1160.56
+    Dragon_Fruit 738.21
+    Rutabaga 364.87
+    Parsley 314.42
+    Cranberry 1621.38
+    Blackberry 662.97
+    Tomato 252.90
+    Dill 601.83
+    Kiwano 67.54
+    Potato 883.99
+    Nectarine 833.07
+    Lemon 497.39
+    Goji_Berry 548.02
+    Kohlrabi 381.31
+    Orange 592.27
+    Spinach 698.04
+    Cabbage 214.69
+    Zucchini 479.01
+    Lettuce 432.96
+    Cucumber 777.24
+    Banana 469.90
+    Peach 569.22
+    Avocado 716.20
+    Starfruit 371.93
+    Lime 367.98
+    Watercress 395.11
+    Artichoke 1307.39
+    Date 610.19
+    Mango 428.85
+    Peas 258.16
+    Fig 485.46
+    Bok_Choy 551.23
+    Carrot 983.16
+    Persimmon 499.70
+    Pear 421.20
+    Radish 549.57
+    Plum 713.06
+    Watermelon 253.89
+    Chard 651.07
+    Kiwi 366.72
+    Apple 663.57
+    Passion_Fruit 394.01
+    Broccoli 584.36
+    Celery 515.16
+    Sage 415.05
+    Papaya 710.80
+    Eggplant 563.79
+    Cilantro 263.09
+    Apricot 456.87
+    Jicama 333.30
+    Cactus_Pear 603.87
+    Collard_Greens 260.70
+    Rosemary 705.79
+    Guava 561.36
+    Plantain 552.53
+    Beet 434.79
+    Onion 428.70
+    Grapes 550.51
+    Endive 417.47
+    Raspberry 199.97
+    Honeydew 1260.60
+    Basil 571.87
+    Oregano 464.72
+    Acorn_Squash 344.08
+    Garlic 647.83
+    Currant 386.44
+    Coconut 1276.13
+    Pomegranate 1294.14
+    Jackfruit 648.52
+    Green_Beans 694.16
+    Blueberry 480.28
+    Rhubarb 596.40
+    Strawberry 722.98
+    Asparagus 415.45
+    Okra 594.95
+    Parsnip 536.53
+    Kale 282.41
+    Pineapple 492.52
+    Butternut_Squash 539.24
+    Yam 378.96
+    Brussels_Sprouts 539.39
+    Squash_Blossom 494.02
+    Cauliflower 644.39
+    Clementine 673.92
+    Mint 309.49
+    Bell_Pepper 371.66
+    Sweet_Potato 537.90
+    Turnip 658.01
+    Grapefruit 393.35
+    Salsify 471.33
+    Pumpkin 226.87
+    Ginger 512.56
+    Cherry 209.76
+    Goulmima 49139.71
+    Pumpkin 352.48
+    Parsnip 737.66
+    Clementine 385.26
+    Jackfruit 543.45
+    Endive 647.55
+    Onion 669.09
+    Cactus_Pear 544.32
+    Sage 892.76
+    Date 497.24
+    Currant 311.80
+    Artichoke 880.56
+    Papaya 479.14
+    Yam 549.55
+    Pear 542.22
+    Eggplant 260.50
+    Peach 451.78
+    Turnip 563.19
+    Grapes 301.51
+    Broccoli 386.14
+    Avocado 466.67
+    Cherry 661.25
+    Lime 357.04
+    Grapefruit 301.12
+    Ginger 375.45
+    Blueberry 606.95
+    Oregano 508.96
+    Nectarine 575.47
+    Kale 543.75
+    Pineapple 535.24
+    Asparagus 639.32
+    Potato 497.70
+    Peas 359.16
+    Passion_Fruit 322.67
+    Cabbage 535.99
+    Watercress 349.67
+    Cauliflower 501.09
+    Lettuce 430.14
+    Salsify 495.48
+    Raspberry 461.77
+    Zucchini 717.28
+    Squash_Blossom 343.02
+    Dragon_Fruit 548.63
+    Rhubarb 270.59
+    Beet 339.79
+    Mint 997.83
+    Sweet_Potato 601.24
+    Cilantro 395.74
+    Rosemary 286.01
+    Carrot 428.72
+    Acorn_Squash 524.83
+    Blackberry 440.89
+    Spinach 659.44
+    Goji_Berry 339.58
+    Mango 820.77
+    Apricot 714.08
+    Pomegranate 1059.57
+    Dill 329.30
+    Thyme 333.93
+    Kiwi 403.07
+    Honeydew 924.28
+    Apple 713.50
+    Chard 681.25
+    Collard_Greens 557.22
+    Rutabaga 760.00
+    Orange 436.61
+    Bell_Pepper 212.60
+    Cranberry 1271.19
+    Cantaloupe 1164.37
+    Coconut 568.51
+    Tomato 623.69
+    Okra 621.31
+    Basil 329.22
+    Guava 451.49
+    Banana 553.29
+    Cucumber 619.31
+    Bok_Choy 587.25
+    Garlic 563.34
+    Watermelon 345.25
+    Kiwano 589.52
+    Strawberry 130.58
+    Fig 526.46
+    Plum 364.15
+    Persimmon 402.54
+    Brussels_Sprouts 582.73
+    Butternut_Squash 606.23
+    Radish 485.36
+    Parsley 521.05
+    Jicama 304.09
+    Green_Beans 295.99
+    Kohlrabi 516.11
+    Lemon 427.45
+    Plantain 446.48
+    Celery 566.49
+    Starfruit 315.40
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:24:57Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:24:57Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:24:57Z INFO  blarun] Submission from user: RedOne KaiTo has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:24:57Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/abounab13/main.c"
+[2024-03-10T15:24:57Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpYHB3gc/sol" with exit code: exit status: 0
+[2024-03-10T15:24:57Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:24:57Z DEBUG blarun] The current started process has pid: 349088
+[2024-03-10T15:24:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:57Z DEBUG blarun] Correctness execution finished in: 62.224869ms
+[2024-03-10T15:24:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:57Z DEBUG blarun] Comparing output "/tmp/.tmpDFQuzA/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:24:57Z DEBUG blarun] The current started process has pid: 349089
+[2024-03-10T15:24:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:57Z DEBUG blarun] Correctness execution finished in: 63.640678ms
+[2024-03-10T15:24:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:24:57Z DEBUG blarun] Comparing output "/tmp/.tmpDFQuzA/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:24:57Z DEBUG blarun] The current started process has pid: 349090
+[2024-03-10T15:24:57Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:24:57Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:24:57Z DEBUG blarun] Correctness execution finished in: 62.622752ms
+[2024-03-10T15:24:57Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:24:57Z DEBUG blarun] Comparing output "/tmp/.tmpDFQuzA/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:24:57Z INFO  blarun] Solution comparison failed, output for the solution is: El_Jadida 45848.19
+    Acorn_Squash 1.03
+    Eggplant 1.14
+    Sweet_Potato 1.35
+    Cactus_Pear 1.47
+    Watercress 1.49
+     expected output is El_Jadida 45848.19
+    Acorn_Squash 1.03
+    Eggplant 1.14
+    Sweet_Potato 1.35
+    Cactus_Pear 1.47
+    Nectarine 1.49
+    
+    
+[2024-03-10T15:24:57Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:24:57Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:24:57Z INFO  blarun] Submission from user: abounab13 has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:24:57Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/MedddAmine/Main.cpp"
+/home/maxheap/blanat/submissions/MedddAmine/Main.cpp: In function ‘void processInputData(std::string, std::unordered_map<std::__cxx11::basic_string<char>, CityData>&)’:
+/home/maxheap/blanat/submissions/MedddAmine/Main.cpp:26:25: error: variable ‘std::stringstream ss’ has initializer but incomplete type
+   26 |     stringstream ss(line);
+      |                         ^
+/home/maxheap/blanat/submissions/MedddAmine/Main.cpp: In function ‘void writeOutput(std::string, std::string, std::vector<Product>&, std::unordered_map<std::__cxx11::basic_string<char>, CityData>&)’:
+/home/maxheap/blanat/submissions/MedddAmine/Main.cpp:86:35: error: ‘setprecision’ was not declared in this scope
+   86 |   file << city << " " << fixed << setprecision(2) << cityMap[city].totalPrice << "\n";
+      |                                   ^~~~~~~~~~~~
+[2024-03-10T15:24:58Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp30fyE0/sol" with exit code: exit status: 1
+[2024-03-10T15:24:58Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/MedddAmine/Main.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "MedddAmine" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T15:24:58Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Ktounoussi/Main.java"
+[2024-03-10T15:24:59Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpLnyrDq/Main.java" with exit code: exit status: 0
+[2024-03-10T15:24:59Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:24:59Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Ktounoussi/Main.java" to "/tmp/.tmplogSlw/Main.java"
+[2024-03-10T15:24:59Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T15:25:00Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmplogSlw/Main.java" with exit code: exit status: 0
+[2024-03-10T15:25:00Z DEBUG blarun] The current started process has pid: 349157
+[2024-03-10T15:25:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:00Z DEBUG blarun] Correctness execution finished in: 316.688066ms
+[2024-03-10T15:25:00Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z DEBUG blarun] Comparing output "/tmp/.tmplogSlw/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45417.59
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:25:00Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:25:00Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:25:00Z INFO  blarun] Submission from user: Ktounoussi has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:25:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/scorpionTaj/main.c"
+[2024-03-10T15:25:00Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpLMivfI/sol" with exit code: exit status: 0
+[2024-03-10T15:25:00Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:25:00Z DEBUG blarun] The current started process has pid: 349211
+[2024-03-10T15:25:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:00Z DEBUG blarun] Correctness execution finished in: 43.172151ms
+[2024-03-10T15:25:00Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z DEBUG blarun] Comparing output "/tmp/.tmpoEjJHt/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z INFO  blarun] Solution comparison failed, output for the solution is: Settat 46254.38
+    Peach 1.08
+    Passion_Fruit 1.13
+    Cranberry 1.21
+    Rutabaga 1.27
+    Spinach 1.41
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:25:00Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:25:00Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:25:00Z INFO  blarun] Submission from user: scorpionTaj has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:25:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/selmouadin/solution.php"
+[2024-03-10T15:25:00Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:25:00Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/selmouadin/solution.php" to "/tmp/.tmpsyG8Sm/sol.php"
+[2024-03-10T15:25:00Z DEBUG blarun] The current started process has pid: 349212
+[2024-03-10T15:25:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:00Z DEBUG blarun] Correctness execution finished in: 192.573657ms
+[2024-03-10T15:25:00Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z DEBUG blarun] Comparing output "/tmp/.tmpsyG8Sm/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:00Z DEBUG blarun] The current started process has pid: 349213
+[2024-03-10T15:25:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:00Z DEBUG blarun] Correctness execution finished in: 86.990294ms
+[2024-03-10T15:25:00Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:25:00Z DEBUG blarun] Comparing output "/tmp/.tmpsyG8Sm/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:25:00Z INFO  blarun] Solution comparison failed, output for the solution is: Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.1
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+     expected output is Layoune 45875.01
+    Plum 1.09
+    Rutabaga 1.10
+    Eggplant 1.16
+    Green_Beans 1.19
+    Acorn_Squash 1.29
+    
+    
+[2024-03-10T15:25:00Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:25:00Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:25:00Z INFO  blarun] Submission from user: selmouadin has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:25:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/elbeqqal94/solution.js"
+[2024-03-10T15:25:00Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:25:00Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/elbeqqal94/solution.js" to "/tmp/.tmpiTCOci/main.js"
+[2024-03-10T15:25:00Z DEBUG blarun] The current started process has pid: 349214
+[2024-03-10T15:25:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+node:events:495
+      throw er; // Unhandled 'error' event
+      ^
+
+Error: ENOENT: no such file or directory, open '../../input.txt'
+Emitted 'error' event on Interface instance at:
+    at ReadStream.onerror (node:internal/readline/interface:246:10)
+    at ReadStream.emit (node:events:517:28)
+    at emitErrorNT (node:internal/streams/destroy:151:8)
+    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
+    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
+  errno: -2,
+  code: 'ENOENT',
+  syscall: 'open',
+  path: '../../input.txt'
+}
+
+Node.js v18.19.0
+[2024-03-10T15:25:01Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T15:25:01Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/elbeqqal94/solution.js", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "elbeqqal94" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T15:25:01Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/alixboun/main.c"
+[2024-03-10T15:25:01Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp3wSk3W/sol" with exit code: exit status: 0
+[2024-03-10T15:25:01Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:25:01Z DEBUG blarun] The current started process has pid: 349230
+[2024-03-10T15:25:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:01Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:01Z DEBUG blarun] Correctness execution finished in: 41.388393ms
+[2024-03-10T15:25:01Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:01Z DEBUG blarun] Comparing output "/tmp/.tmpzjmZtF/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:01Z INFO  blarun] Solution comparison failed, output for the solution is: Settat 40.82
+    Rosemary 40.82
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:25:01Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:25:01Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:25:01Z INFO  blarun] Submission from user: alixboun has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:25:01Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/conan/Main.java"
+[2024-03-10T15:25:02Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpiDyFGE/Main.java" with exit code: exit status: 0
+[2024-03-10T15:25:02Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:25:02Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/conan/Main.java" to "/tmp/.tmptn95b7/Main.java"
+[2024-03-10T15:25:02Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T15:25:02Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmptn95b7/Main.java" with exit code: exit status: 0
+[2024-03-10T15:25:02Z DEBUG blarun] The current started process has pid: 349294
+[2024-03-10T15:25:02Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:04Z DEBUG blarun] Correctness execution finished in: 1.350589189s
+[2024-03-10T15:25:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:04Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:25:04Z DEBUG blarun] The current started process has pid: 349328
+[2024-03-10T15:25:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:05Z DEBUG blarun] Correctness execution finished in: 1.31278809s
+[2024-03-10T15:25:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:25:05Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:25:05Z DEBUG blarun] The current started process has pid: 349362
+[2024-03-10T15:25:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:06Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:06Z DEBUG blarun] Correctness execution finished in: 1.33856375s
+[2024-03-10T15:25:06Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:25:06Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:25:06Z DEBUG blarun] The current started process has pid: 349396
+[2024-03-10T15:25:06Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:08Z DEBUG blarun] Correctness execution finished in: 1.342416503s
+[2024-03-10T15:25:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:25:08Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:25:08Z DEBUG blarun] The current started process has pid: 349430
+[2024-03-10T15:25:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:09Z DEBUG blarun] Correctness execution finished in: 1.315586596s
+[2024-03-10T15:25:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:25:09Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:25:09Z DEBUG blarun] The current started process has pid: 349464
+[2024-03-10T15:25:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:10Z DEBUG blarun] Correctness execution finished in: 1.328887882s
+[2024-03-10T15:25:10Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:25:10Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:25:10Z DEBUG blarun] The current started process has pid: 349498
+[2024-03-10T15:25:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:12Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:12Z DEBUG blarun] Correctness execution finished in: 1.35740016s
+[2024-03-10T15:25:12Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:25:12Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:25:12Z DEBUG blarun] The current started process has pid: 349532
+[2024-03-10T15:25:12Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:13Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:13Z DEBUG blarun] Correctness execution finished in: 1.33335723s
+[2024-03-10T15:25:13Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:25:13Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:25:13Z DEBUG blarun] The current started process has pid: 349566
+[2024-03-10T15:25:13Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:14Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:14Z DEBUG blarun] Correctness execution finished in: 1.331737991s
+[2024-03-10T15:25:14Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:25:14Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:25:14Z DEBUG blarun] The current started process has pid: 349600
+[2024-03-10T15:25:14Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:25:16Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:25:16Z DEBUG blarun] Correctness execution finished in: 1.43920412s
+[2024-03-10T15:25:16Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:25:16Z DEBUG blarun] Comparing output "/tmp/.tmptn95b7/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:25:16Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:25:16Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:25:16Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpiDyFGE/input.txt"
+[2024-03-10T15:25:16Z DEBUG blarun] Starting execution run #0
+[2024-03-10T15:25:16Z DEBUG blarun] The current started process has pid: 349638
+[2024-03-10T15:25:16Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:16Z DEBUG blarun] Child process timed out
+[2024-03-10T15:35:16Z DEBUG blarun] Killed with exit code: None
+[2024-03-10T15:35:16Z INFO  blarun] Submission from user: conan has finished with verdict: Tle and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:35:16Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/ylizma/Main.java"
+[2024-03-10T15:35:17Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpFeYJty/Main.java" with exit code: exit status: 0
+[2024-03-10T15:35:17Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:35:17Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/ylizma/Main.java" to "/tmp/.tmp1ufg4v/Main.java"
+[2024-03-10T15:35:17Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T15:35:17Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmp1ufg4v/Main.java" with exit code: exit status: 0
+[2024-03-10T15:35:17Z DEBUG blarun] The current started process has pid: 349748
+[2024-03-10T15:35:17Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:18Z DEBUG blarun] Correctness execution finished in: 291.104796ms
+[2024-03-10T15:35:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:18Z DEBUG blarun] Comparing output "/tmp/.tmp1ufg4v/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:18Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45285.29
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:35:18Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:35:18Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:35:18Z INFO  blarun] Submission from user: ylizma has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:35:18Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Amine-H/main.js"
+[2024-03-10T15:35:18Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:35:18Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/Amine-H/main.js" to "/tmp/.tmpYH1G8n/main.js"
+[2024-03-10T15:35:18Z DEBUG blarun] The current started process has pid: 349797
+[2024-03-10T15:35:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:18Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:18Z DEBUG blarun] Correctness execution finished in: 622.976631ms
+[2024-03-10T15:35:18Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:18Z DEBUG blarun] Comparing output "/tmp/.tmpYH1G8n/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:18Z DEBUG blarun] The current started process has pid: 349824
+[2024-03-10T15:35:18Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:19Z DEBUG blarun] Correctness execution finished in: 378.521043ms
+[2024-03-10T15:35:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:19Z DEBUG blarun] Comparing output "/tmp/.tmpYH1G8n/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:19Z DEBUG blarun] The current started process has pid: 349851
+[2024-03-10T15:35:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:19Z DEBUG blarun] Correctness execution finished in: 373.652895ms
+[2024-03-10T15:35:19Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:19Z DEBUG blarun] Comparing output "/tmp/.tmpYH1G8n/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:19Z DEBUG blarun] The current started process has pid: 349878
+[2024-03-10T15:35:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:20Z DEBUG blarun] Correctness execution finished in: 366.223655ms
+[2024-03-10T15:35:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:20Z DEBUG blarun] Comparing output "/tmp/.tmpYH1G8n/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:20Z INFO  blarun] Solution comparison failed, output for the solution is: Safi 44921.59
+    Plantain 1.04
+    Potato 1.32
+    Salsify 1.32
+    Artichoke 1.76
+    Artichoke 1.76
+    
+     expected output is Safi 44921.59
+    Plantain 1.04
+    Potato 1.32
+    Salsify 1.32
+    Artichoke 1.76
+    Bell_Pepper 1.77
+    
+[2024-03-10T15:35:20Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:35:20Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:35:20Z INFO  blarun] Submission from user: Amine-H has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:35:20Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/bondif/Main.java"
+[2024-03-10T15:35:20Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpXbZ01z/Main.java" with exit code: exit status: 0
+[2024-03-10T15:35:20Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:35:20Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/bondif/Main.java" to "/tmp/.tmpfL2KxK/Main.java"
+[2024-03-10T15:35:20Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T15:35:21Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpfL2KxK/Main.java" with exit code: exit status: 0
+[2024-03-10T15:35:21Z DEBUG blarun] The current started process has pid: 349969
+[2024-03-10T15:35:21Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:21Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:21Z DEBUG blarun] Correctness execution finished in: 478.282035ms
+[2024-03-10T15:35:21Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:21Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:21Z DEBUG blarun] The current started process has pid: 350026
+[2024-03-10T15:35:21Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:22Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:22Z DEBUG blarun] Correctness execution finished in: 478.180465ms
+[2024-03-10T15:35:22Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:22Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:22Z DEBUG blarun] The current started process has pid: 350084
+[2024-03-10T15:35:22Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:22Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:22Z DEBUG blarun] Correctness execution finished in: 473.922012ms
+[2024-03-10T15:35:22Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:22Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:22Z DEBUG blarun] The current started process has pid: 350141
+[2024-03-10T15:35:22Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:23Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:23Z DEBUG blarun] Correctness execution finished in: 485.257377ms
+[2024-03-10T15:35:23Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:23Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:23Z DEBUG blarun] The current started process has pid: 350198
+[2024-03-10T15:35:23Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:23Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:23Z DEBUG blarun] Correctness execution finished in: 477.407291ms
+[2024-03-10T15:35:23Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:35:23Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:35:23Z DEBUG blarun] The current started process has pid: 350255
+[2024-03-10T15:35:23Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:24Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:24Z DEBUG blarun] Correctness execution finished in: 449.91263ms
+[2024-03-10T15:35:24Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:35:24Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:35:24Z DEBUG blarun] The current started process has pid: 350312
+[2024-03-10T15:35:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:24Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:24Z DEBUG blarun] Correctness execution finished in: 450.752152ms
+[2024-03-10T15:35:24Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:35:24Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:35:24Z DEBUG blarun] The current started process has pid: 350369
+[2024-03-10T15:35:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:25Z DEBUG blarun] Correctness execution finished in: 442.616982ms
+[2024-03-10T15:35:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:35:25Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:35:25Z DEBUG blarun] The current started process has pid: 350426
+[2024-03-10T15:35:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:25Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:25Z DEBUG blarun] Correctness execution finished in: 442.398988ms
+[2024-03-10T15:35:25Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:35:25Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:35:25Z DEBUG blarun] The current started process has pid: 350483
+[2024-03-10T15:35:25Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:26Z DEBUG blarun] Correctness execution finished in: 466.916639ms
+[2024-03-10T15:35:26Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:35:26Z DEBUG blarun] Comparing output "/tmp/.tmpfL2KxK/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:35:26Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:35:26Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:35:26Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpXbZ01z/input.txt"
+[2024-03-10T15:35:26Z DEBUG blarun] Starting execution run #0
+[2024-03-10T15:35:26Z DEBUG blarun] The current started process has pid: 350542
+[2024-03-10T15:35:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Exception in thread "main" java.lang.OutOfMemoryError: Java heap space
+	at java.base/java.util.Arrays.copyOf(Arrays.java:3512)
+	at java.base/java.util.Arrays.copyOf(Arrays.java:3481)
+	at java.base/java.util.ArrayList.grow(ArrayList.java:237)
+	at java.base/java.util.ArrayList.grow(ArrayList.java:244)
+	at java.base/java.util.ArrayList.add(ArrayList.java:454)
+	at java.base/java.util.ArrayList.add(ArrayList.java:467)
+	at java.base/java.util.stream.Collectors$$Lambda$4/0x00007f2c50049bc8.accept(Unknown Source)
+	at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
+	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
+	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
+	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
+	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
+	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
+	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
+	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
+	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
+	at Main.main(Main.java:61)
+[2024-03-10T15:35:36Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T15:35:36Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/bondif/Main.java", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "bondif" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T15:35:36Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/AnasImloul/main.cpp"
+/home/maxheap/blanat/submissions/AnasImloul/main.cpp: In function ‘int main()’:
+/home/maxheap/blanat/submissions/AnasImloul/main.cpp:133:24: error: ‘setprecision’ was not declared in this scope
+  133 |     output << fixed << setprecision(2);
+      |                        ^~~~~~~~~~~~
+[2024-03-10T15:35:37Z INFO  blarun] Finished compilation of the target: "/tmp/.tmphxcFGR/sol" with exit code: exit status: 1
+[2024-03-10T15:35:37Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/AnasImloul/main.cpp", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "AnasImloul" } with error: Failed to compile solution file: none-zero exit code
+[2024-03-10T15:35:37Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/bilalix/solution.py"
+[2024-03-10T15:35:37Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:35:37Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/bilalix/solution.py" to "/tmp/.tmpyxhQzn/main.py"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350596
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Traceback (most recent call last):
+  File "/tmp/.tmpyxhQzn/main.py", line 70, in <module>
+    main("input_1b.txt", "output.txt")
+  File "/tmp/.tmpyxhQzn/main.py", line 63, in main
+    city_totals, city_products = read_and_process_data(input_file_path)
+                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/tmp/.tmpyxhQzn/main.py", line 20, in read_and_process_data
+    with open(input_file_path, mode='r', newline='') as file:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: 'input_1b.txt'
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T15:35:37Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/bilalix/solution.py", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "bilalix" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T15:35:37Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/anassajaanan/main.c"
+[2024-03-10T15:35:37Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpbpW7tL/sol" with exit code: exit status: 0
+[2024-03-10T15:35:37Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350602
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 18.811713ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350627
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.420636ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350652
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.669911ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350677
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.227335ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350702
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.247039ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350727
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.407156ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350752
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.334404ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350777
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.226345ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350802
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.488256ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350827
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:35:37Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:35:37Z DEBUG blarun] Correctness execution finished in: 5.19147ms
+[2024-03-10T15:35:37Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:35:37Z DEBUG blarun] Comparing output "/tmp/.tmp7XrMMf/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:35:37Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:35:37Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:35:37Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpbpW7tL/input.txt"
+[2024-03-10T15:35:37Z DEBUG blarun] Starting execution #0
+[2024-03-10T15:35:37Z DEBUG blarun] The current started process has pid: 350854
+[2024-03-10T15:35:37Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:36:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:36:55Z DEBUG blarun] Execution #0 finished in: 78.188884259s
+[2024-03-10T15:36:55Z DEBUG blarun] Computing verdict using "/tmp/.tmpbpW7tL/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:36:55Z DEBUG blarun] Comparing output "/tmp/.tmpbpW7tL/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:36:55Z DEBUG blarun] Starting execution #1
+[2024-03-10T15:36:55Z DEBUG blarun] The current started process has pid: 350879
+[2024-03-10T15:36:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:36:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:36:59Z DEBUG blarun] Execution #1 finished in: 3.446951795s
+[2024-03-10T15:36:59Z DEBUG blarun] Computing verdict using "/tmp/.tmpbpW7tL/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:36:59Z DEBUG blarun] Comparing output "/tmp/.tmpbpW7tL/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:36:59Z DEBUG blarun] Starting execution #2
+[2024-03-10T15:36:59Z DEBUG blarun] The current started process has pid: 350904
+[2024-03-10T15:36:59Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:02Z DEBUG blarun] Execution #2 finished in: 3.107137197s
+[2024-03-10T15:37:02Z DEBUG blarun] Computing verdict using "/tmp/.tmpbpW7tL/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:02Z DEBUG blarun] Comparing output "/tmp/.tmpbpW7tL/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:02Z DEBUG blarun] Starting execution #3
+[2024-03-10T15:37:02Z DEBUG blarun] The current started process has pid: 350929
+[2024-03-10T15:37:02Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:05Z DEBUG blarun] Execution #3 finished in: 3.126190466s
+[2024-03-10T15:37:05Z DEBUG blarun] Computing verdict using "/tmp/.tmpbpW7tL/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:05Z DEBUG blarun] Comparing output "/tmp/.tmpbpW7tL/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:05Z DEBUG blarun] Starting execution #4
+[2024-03-10T15:37:05Z DEBUG blarun] The current started process has pid: 350954
+[2024-03-10T15:37:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:08Z DEBUG blarun] Execution #4 finished in: 3.12013734s
+[2024-03-10T15:37:08Z DEBUG blarun] Computing verdict using "/tmp/.tmpbpW7tL/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:08Z DEBUG blarun] Comparing output "/tmp/.tmpbpW7tL/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:37:08Z INFO  blarun] Submission from user: anassajaanan has finished with verdict: Ac and with an AVG execution time of: 3.2310932s and MED of 3.126190466s
+[2024-03-10T15:37:08Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/webNeat/solution.php"
+[2024-03-10T15:37:08Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:37:08Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/webNeat/solution.php" to "/tmp/.tmp7MRYto/sol.php"
+[2024-03-10T15:37:08Z DEBUG blarun] The current started process has pid: 350979
+[2024-03-10T15:37:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:08Z DEBUG blarun] Correctness execution finished in: 162.087576ms
+[2024-03-10T15:37:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:37:08Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:37:08Z DEBUG blarun] The current started process has pid: 350988
+[2024-03-10T15:37:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:08Z DEBUG blarun] Correctness execution finished in: 42.537444ms
+[2024-03-10T15:37:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:37:08Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:37:08Z DEBUG blarun] The current started process has pid: 350997
+[2024-03-10T15:37:08Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:08Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:08Z DEBUG blarun] Correctness execution finished in: 42.50111ms
+[2024-03-10T15:37:08Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:37:08Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:37:08Z DEBUG blarun] The current started process has pid: 351006
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 43.005008ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351015
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 41.748927ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351024
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 42.79835ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351033
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 42.59459ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351042
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 42.950515ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351051
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 42.152033ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:37:09Z DEBUG blarun] The current started process has pid: 351060
+[2024-03-10T15:37:09Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:37:09Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:37:09Z DEBUG blarun] Correctness execution finished in: 42.009197ms
+[2024-03-10T15:37:09Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:37:09Z DEBUG blarun] Comparing output "/tmp/.tmp7MRYto/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:37:09Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:37:09Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:37:10Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpmw6p1Z/input.txt"
+[2024-03-10T15:37:11Z DEBUG blarun] The current started process has pid: 351071
+[2024-03-10T15:37:11Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:38:29Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:38:29Z DEBUG blarun] Execution #0 finished in: 78.594061552s
+[2024-03-10T15:38:29Z DEBUG blarun] Comparing output "/tmp/.tmpmw6p1Z/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:38:29Z DEBUG blarun] The current started process has pid: 351082
+[2024-03-10T15:38:29Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:39:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:39:48Z DEBUG blarun] Execution #1 finished in: 78.413480165s
+[2024-03-10T15:39:48Z DEBUG blarun] Comparing output "/tmp/.tmpmw6p1Z/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:39:48Z DEBUG blarun] The current started process has pid: 351127
+[2024-03-10T15:39:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:40:38Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:40:38Z DEBUG blarun] Execution #2 finished in: 50.556840571s
+[2024-03-10T15:40:38Z DEBUG blarun] Comparing output "/tmp/.tmpmw6p1Z/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:40:38Z DEBUG blarun] The current started process has pid: 351137
+[2024-03-10T15:40:38Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:41:19Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:41:19Z DEBUG blarun] Execution #3 finished in: 40.523545582s
+[2024-03-10T15:41:19Z DEBUG blarun] Comparing output "/tmp/.tmpmw6p1Z/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:41:19Z DEBUG blarun] The current started process has pid: 351146
+[2024-03-10T15:41:19Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:41:59Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:41:59Z DEBUG blarun] Execution #4 finished in: 39.919965938s
+[2024-03-10T15:41:59Z DEBUG blarun] Comparing output "/tmp/.tmpmw6p1Z/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:41:59Z INFO  blarun] Submission from user: webNeat has finished with verdict: Ac and with an AVG execution time of: 56.497955439s and MED of 50.556840571s
+[2024-03-10T15:41:59Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/webNeat/solution.cpp"
+[2024-03-10T15:42:00Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpxedarr/sol" with exit code: exit status: 0
+[2024-03-10T15:42:00Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:42:00Z DEBUG blarun] The current started process has pid: 351160
+[2024-03-10T15:42:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:00Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:00Z DEBUG blarun] Correctness execution finished in: 31.259356ms
+[2024-03-10T15:42:00Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:42:00Z DEBUG blarun] Comparing output "/tmp/.tmpMnMdzf/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:42:00Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Pineapple 1.06
+    Mango 1.61
+    Grapefruit 1.69
+    Oregano 2.02
+    Coconut 2.04
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T15:42:00Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T15:42:00Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T15:42:00Z INFO  blarun] Submission from user: webNeat has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T15:42:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/AITYOUB-Abdelmoughit/main.py"
+[2024-03-10T15:42:00Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:42:00Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/AITYOUB-Abdelmoughit/main.py" to "/tmp/.tmpyMtfqT/main.py"
+[2024-03-10T15:42:00Z DEBUG blarun] The current started process has pid: 351177
+[2024-03-10T15:42:00Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+Traceback (most recent call last):
+  File "/tmp/.tmpyMtfqT/main.py", line 5, in <module>
+    with open("../../input.txt",'r') as data:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+FileNotFoundError: [Errno 2] No such file or directory: '../../input.txt'
+[2024-03-10T15:42:00Z INFO  blarun] Finished execution of the solution with status: Some(1)
+[2024-03-10T15:42:00Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/AITYOUB-Abdelmoughit/main.py", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "AITYOUB-Abdelmoughit" } with error: Failed to run the solution file: none-zero exit code
+[2024-03-10T15:42:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/Hamdane-yassine/solution.rs"
+[2024-03-10T15:42:00Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/Hamdane-yassine/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "Hamdane-yassine" } with error: No such file or directory (os error 2)
+[2024-03-10T15:42:00Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/guizo792/Main.java"
+[2024-03-10T15:42:01Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpxQJHqm/Main.java" with exit code: exit status: 0
+[2024-03-10T15:42:01Z INFO  blarun] Starting correctness checks
+[2024-03-10T15:42:01Z DEBUG blarun] Copying solution source from: "/home/maxheap/blanat/submissions/guizo792/Main.java" to "/tmp/.tmpY70eK3/Main.java"
+[2024-03-10T15:42:01Z DEBUG blarun] Recompiling Java solution for correctness checks
+[2024-03-10T15:42:01Z DEBUG blarun] Finished compilation of the target: "/tmp/.tmpY70eK3/Main.java" with exit code: exit status: 0
+[2024-03-10T15:42:01Z DEBUG blarun] The current started process has pid: 351242
+[2024-03-10T15:42:01Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:02Z DEBUG blarun] Correctness execution finished in: 408.975192ms
+[2024-03-10T15:42:02Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:42:02Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T15:42:02Z DEBUG blarun] The current started process has pid: 351281
+[2024-03-10T15:42:02Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:02Z DEBUG blarun] Correctness execution finished in: 365.717417ms
+[2024-03-10T15:42:02Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:42:02Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T15:42:02Z DEBUG blarun] The current started process has pid: 351320
+[2024-03-10T15:42:02Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:02Z DEBUG blarun] Correctness execution finished in: 357.91402ms
+[2024-03-10T15:42:02Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:42:02Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T15:42:02Z DEBUG blarun] The current started process has pid: 351359
+[2024-03-10T15:42:02Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:03Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:03Z DEBUG blarun] Correctness execution finished in: 372.525282ms
+[2024-03-10T15:42:03Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:42:03Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T15:42:03Z DEBUG blarun] The current started process has pid: 351398
+[2024-03-10T15:42:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:03Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:03Z DEBUG blarun] Correctness execution finished in: 377.194416ms
+[2024-03-10T15:42:03Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:42:03Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T15:42:03Z DEBUG blarun] The current started process has pid: 351437
+[2024-03-10T15:42:03Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:04Z DEBUG blarun] Correctness execution finished in: 394.912398ms
+[2024-03-10T15:42:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:42:04Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T15:42:04Z DEBUG blarun] The current started process has pid: 351476
+[2024-03-10T15:42:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:04Z DEBUG blarun] Correctness execution finished in: 336.705409ms
+[2024-03-10T15:42:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:42:04Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T15:42:04Z DEBUG blarun] The current started process has pid: 351515
+[2024-03-10T15:42:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:04Z DEBUG blarun] Correctness execution finished in: 369.543438ms
+[2024-03-10T15:42:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:42:04Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T15:42:04Z DEBUG blarun] The current started process has pid: 351554
+[2024-03-10T15:42:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:05Z DEBUG blarun] Correctness execution finished in: 375.000447ms
+[2024-03-10T15:42:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:42:05Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T15:42:05Z DEBUG blarun] The current started process has pid: 351593
+[2024-03-10T15:42:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:42:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:42:05Z DEBUG blarun] Correctness execution finished in: 364.860726ms
+[2024-03-10T15:42:05Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:42:05Z DEBUG blarun] Comparing output "/tmp/.tmpY70eK3/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T15:42:05Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T15:42:05Z INFO  blarun] Dropping the file cache
+[2024-03-10T15:42:07Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpxQJHqm/input.txt"
+[2024-03-10T15:42:07Z DEBUG blarun] Starting execution run #0
+[2024-03-10T15:42:07Z DEBUG blarun] The current started process has pid: 351634
+[2024-03-10T15:42:07Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:47:48Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:47:48Z DEBUG blarun] Execution #0 finished in: 341.192665125s
+[2024-03-10T15:47:48Z DEBUG blarun] Computing verdict using "/tmp/.tmpxQJHqm/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:47:48Z DEBUG blarun] Comparing output "/tmp/.tmpxQJHqm/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:47:48Z DEBUG blarun] Starting execution run #1
+[2024-03-10T15:47:48Z DEBUG blarun] The current started process has pid: 351713
+[2024-03-10T15:47:48Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:53:34Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:53:34Z DEBUG blarun] Execution #1 finished in: 345.490297817s
+[2024-03-10T15:53:34Z DEBUG blarun] Computing verdict using "/tmp/.tmpxQJHqm/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:53:34Z DEBUG blarun] Comparing output "/tmp/.tmpxQJHqm/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:53:34Z DEBUG blarun] Starting execution run #2
+[2024-03-10T15:53:34Z DEBUG blarun] The current started process has pid: 351791
+[2024-03-10T15:53:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T15:59:21Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T15:59:21Z DEBUG blarun] Execution #2 finished in: 347.311444494s
+[2024-03-10T15:59:21Z DEBUG blarun] Computing verdict using "/tmp/.tmpxQJHqm/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:59:21Z DEBUG blarun] Comparing output "/tmp/.tmpxQJHqm/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T15:59:21Z DEBUG blarun] Starting execution run #3
+[2024-03-10T15:59:21Z DEBUG blarun] The current started process has pid: 351857
+[2024-03-10T15:59:21Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:05:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:05:10Z DEBUG blarun] Execution #3 finished in: 349.495488459s
+[2024-03-10T16:05:10Z DEBUG blarun] Computing verdict using "/tmp/.tmpxQJHqm/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:05:10Z DEBUG blarun] Comparing output "/tmp/.tmpxQJHqm/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:05:10Z DEBUG blarun] Starting execution run #4
+[2024-03-10T16:05:10Z DEBUG blarun] The current started process has pid: 351931
+[2024-03-10T16:05:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:02Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:02Z DEBUG blarun] Execution #4 finished in: 352.113215293s
+[2024-03-10T16:11:02Z DEBUG blarun] Computing verdict using "/tmp/.tmpxQJHqm/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:11:02Z DEBUG blarun] Comparing output "/tmp/.tmpxQJHqm/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:11:02Z INFO  blarun] Submission from user: guizo792 has finished with verdict: Ac and with an AVG execution time of: 347.432410256s and MED of 347.311444494s
+[2024-03-10T16:11:02Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/k34n4y138/program.cpp"
+[2024-03-10T16:11:04Z INFO  blarun] Finished compilation of the target: "/tmp/.tmp4wr9n5/sol" with exit code: exit status: 0
+[2024-03-10T16:11:04Z INFO  blarun] Starting correctness checks
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352032
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 16.74425ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352065
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 30.988204ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352098
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.57257ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352131
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.353289ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352164
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.360025ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352197
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.329223ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352230
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.302689ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352263
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.224091ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352296
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.238471ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T16:11:04Z DEBUG blarun] The current started process has pid: 352329
+[2024-03-10T16:11:04Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:11:04Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:11:04Z DEBUG blarun] Correctness execution finished in: 5.905291ms
+[2024-03-10T16:11:04Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T16:11:04Z DEBUG blarun] Comparing output "/tmp/.tmpzfYvUw/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T16:11:04Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T16:11:04Z INFO  blarun] Dropping the file cache
+[2024-03-10T16:11:05Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmp4wr9n5/input.txt"
+[2024-03-10T16:11:05Z DEBUG blarun] Starting execution #0
+[2024-03-10T16:11:05Z DEBUG blarun] The current started process has pid: 352364
+[2024-03-10T16:11:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:12:23Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:12:23Z DEBUG blarun] Execution #0 finished in: 78.1720787s
+[2024-03-10T16:12:23Z DEBUG blarun] Computing verdict using "/tmp/.tmp4wr9n5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:23Z DEBUG blarun] Comparing output "/tmp/.tmp4wr9n5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:23Z DEBUG blarun] Starting execution #1
+[2024-03-10T16:12:23Z DEBUG blarun] The current started process has pid: 352399
+[2024-03-10T16:12:24Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:12:26Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:12:26Z DEBUG blarun] Execution #1 finished in: 2.590200348s
+[2024-03-10T16:12:26Z DEBUG blarun] Computing verdict using "/tmp/.tmp4wr9n5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:26Z DEBUG blarun] Comparing output "/tmp/.tmp4wr9n5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:26Z DEBUG blarun] Starting execution #2
+[2024-03-10T16:12:26Z DEBUG blarun] The current started process has pid: 352432
+[2024-03-10T16:12:26Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:12:28Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:12:28Z DEBUG blarun] Execution #2 finished in: 1.923043456s
+[2024-03-10T16:12:28Z DEBUG blarun] Computing verdict using "/tmp/.tmp4wr9n5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:28Z DEBUG blarun] Comparing output "/tmp/.tmp4wr9n5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:28Z DEBUG blarun] Starting execution #3
+[2024-03-10T16:12:28Z DEBUG blarun] The current started process has pid: 352465
+[2024-03-10T16:12:28Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:12:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:12:30Z DEBUG blarun] Execution #3 finished in: 1.915654069s
+[2024-03-10T16:12:30Z DEBUG blarun] Computing verdict using "/tmp/.tmp4wr9n5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:30Z DEBUG blarun] Comparing output "/tmp/.tmp4wr9n5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:30Z DEBUG blarun] Starting execution #4
+[2024-03-10T16:12:30Z DEBUG blarun] The current started process has pid: 352498
+[2024-03-10T16:12:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T16:12:32Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T16:12:32Z DEBUG blarun] Execution #4 finished in: 1.877388914s
+[2024-03-10T16:12:32Z DEBUG blarun] Computing verdict using "/tmp/.tmp4wr9n5/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:32Z DEBUG blarun] Comparing output "/tmp/.tmp4wr9n5/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T16:12:32Z INFO  blarun] Submission from user: k34n4y138 has finished with verdict: Ac and with an AVG execution time of: 2.142965957s and MED of 1.923043456s
+[2024-03-10T16:12:32Z DEBUG blarun] Changed path: "/home/maxheap/blanat/submissions/kmoz000/main.c"
+/home/maxheap/blanat/submissions/kmoz000/main.c: In function ‘void readDataFromFile(const char*, ProductEntry**, int*)’:
+/home/maxheap/blanat/submissions/kmoz000/main.c:37:44: error: invalid conversion from ‘void*’ to ‘ProductEntry*’ [-fpermissive]
+   37 |         ProductEntry *newTempData = realloc(tempData, (count + 1) * sizeof(ProductEntry));
+      |                                     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                            |
+      |                                            void*
+/home/maxheap/blanat/submissions/kmoz000/main.c: In function ‘void calculateTotalCostByCity(ProductEntry*, int, CityEntry**, int*)’:
+/home/maxheap/blanat/submissions/kmoz000/main.c:102:21: error: invalid conversion from ‘void*’ to ‘CityEntry*’ [-fpermissive]
+  102 |     *cities = malloc(*numCities * sizeof(CityEntry));
+      |               ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                     |
+      |                     void*
+[2024-03-10T16:12:32Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpSLUbkx/sol" with exit code: exit status: 1
+[2024-03-10T16:12:32Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/blanat/submissions/kmoz000/main.c", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/blanat/", user: "kmoz000" } with error: Failed to compile solution file: none-zero exit code
+--> Manually added Rust only runs
+[2024-03-10T17:43:19Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/aarrasseayoub01/solution.rs"
+warning: function `read_lines` is never used
+  --> /home/maxheap/testdir/submissions/aarrasseayoub01/solution.rs:82:4
+   |
+82 | fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+   |    ^^^^^^^^^^
+   |
+   = note: `#[warn(dead_code)]` on by default
+
+warning: 1 warning emitted
+
+[2024-03-10T17:43:20Z INFO  blarun] Finished compilation of the target: "/tmp/.tmptSzsIF/sol" with exit code: exit status: 0
+[2024-03-10T17:43:20Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355708
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 47.908492ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355725
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 31.943582ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355742
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 32.277975ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355759
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 31.905926ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355776
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 32.758751ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355793
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 32.351222ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355810
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 33.691795ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355827
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 31.946004ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355844
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 31.966473ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355861
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:20Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:20Z DEBUG blarun] Correctness execution finished in: 32.067676ms
+[2024-03-10T17:43:20Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:43:20Z DEBUG blarun] Comparing output "/tmp/.tmpJbMFY9/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:43:20Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T17:43:20Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmptSzsIF/input.txt"
+[2024-03-10T17:43:20Z DEBUG blarun] Starting execution #0
+[2024-03-10T17:43:20Z DEBUG blarun] The current started process has pid: 355878
+[2024-03-10T17:43:20Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:45Z INFO  blarun] Finished execution of the solution with status: None
+[2024-03-10T17:43:45Z DEBUG blarun] Execution #0 finished in: 24.656905554s
+[2024-03-10T17:43:45Z DEBUG blarun] Computing verdict using "/tmp/.tmptSzsIF/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:43:45Z DEBUG blarun] Comparing output "/tmp/.tmptSzsIF/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:43:45Z INFO  blarun] Failed to run RunContext { input_file: "/home/maxheap/blablaconf/input.txt", expected_output: "/home/maxheap/blablaconf/output.txt", solution_file: "/home/maxheap/testdir/submissions/aarrasseayoub01/solution.rs", correctness_data: "/home/maxheap/correctness_tests", timeout: 600s, cgroup_path: "/sys/fs/cgroup/blarun.workload", times: 5, root: "/home/maxheap/testdir/", user: "aarrasseayoub01" } with error: No such file or directory (os error 2)
+[2024-03-10T17:43:45Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/essmehdi/solution.rs"
+warning: unused `Result` that must be used
+   --> /home/maxheap/testdir/submissions/essmehdi/solution.rs:150:17
+    |
+150 |                 process_chunk(result_clone, totals_result_clone, start, end, cities_map_clone, products_map_clone);
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = note: this `Result` may be an `Err` variant, which should be handled
+    = note: `#[warn(unused_must_use)]` on by default
+help: use `let _ = ...` to ignore the resulting value
+    |
+150 |                 let _ = process_chunk(result_clone, totals_result_clone, start, end, cities_map_clone, products_map_clone);
+    |                 +++++++
+
+warning: 1 warning emitted
+
+[2024-03-10T17:43:45Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpFmyr8f/sol" with exit code: exit status: 0
+[2024-03-10T17:43:45Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:43:45Z DEBUG blarun] The current started process has pid: 355910
+[2024-03-10T17:43:45Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:45Z DEBUG blarun] Correctness execution finished in: 39.565391ms
+[2024-03-10T17:43:45Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:45Z DEBUG blarun] Comparing output "/tmp/.tmpco02aF/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:45Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.98
+    Pear 3.48
+    Raspberry 4.50
+    Mint 6.42
+    Clementine 6.46
+    Yam 9.22
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T17:43:45Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T17:43:45Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T17:43:45Z INFO  blarun] Submission from user: essmehdi has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T17:43:45Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/sohaibMan/solution.rs"
+warning: unused variable: `other`
+  --> /home/maxheap/testdir/submissions/sohaibMan/solution.rs:15:18
+   |
+15 |     fn eq(&self, other: &Self) -> bool {
+   |                  ^^^^^ help: if this is intentional, prefix it with an underscore: `_other`
+   |
+   = note: `#[warn(unused_variables)]` on by default
+
+warning: variable `Product` should have a snake case name
+  --> /home/maxheap/testdir/submissions/sohaibMan/solution.rs:89:9
+   |
+89 |     for Product in cheapest_products {
+   |         ^^^^^^^ help: convert the identifier to snake case: `product`
+   |
+   = note: `#[warn(non_snake_case)]` on by default
+
+warning: 2 warnings emitted
+
+[2024-03-10T17:43:46Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpoqgvlI/sol" with exit code: exit status: 0
+[2024-03-10T17:43:46Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 355965
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 39.40531ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpYeu6kc/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:46Z INFO  blarun] Solution comparison failed, output for the solution is: Casablanca 45534.99
+    Blueberry 99.99
+    Dragon_Fruit 99.97
+    Radish 99.70
+    Onion 98.94
+    Artichoke 99.89
+    
+     expected output is Casablanca 45534.98
+    Zucchini 1.05
+    Pineapple 1.06
+    Dill 1.15
+    Eggplant 1.22
+    Cantaloupe 1.41
+    
+[2024-03-10T17:43:46Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T17:43:46Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T17:43:46Z INFO  blarun] Submission from user: sohaibMan has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T17:43:46Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/youssefhamdane/solution.rs"
+[2024-03-10T17:43:46Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpUSN28B/sol" with exit code: exit status: 0
+[2024-03-10T17:43:46Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 355996
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 43.692523ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356014
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.701701ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356032
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.389212ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356050
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.46578ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356068
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.42286ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356086
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.601307ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356104
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.614294ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356122
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 6.202891ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356140
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 6.30834ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356158
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:46Z DEBUG blarun] Correctness execution finished in: 5.207546ms
+[2024-03-10T17:43:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:43:46Z DEBUG blarun] Comparing output "/tmp/.tmpC6fyof/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:43:46Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T17:43:46Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpUSN28B/input.txt"
+[2024-03-10T17:43:46Z DEBUG blarun] Starting execution #0
+[2024-03-10T17:43:46Z DEBUG blarun] The current started process has pid: 356176
+[2024-03-10T17:43:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:43:58Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:43:58Z DEBUG blarun] Execution #0 finished in: 11.760636079s
+[2024-03-10T17:43:58Z DEBUG blarun] Computing verdict using "/tmp/.tmpUSN28B/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:43:58Z DEBUG blarun] Comparing output "/tmp/.tmpUSN28B/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:43:58Z DEBUG blarun] Starting execution #1
+[2024-03-10T17:43:58Z DEBUG blarun] The current started process has pid: 356194
+[2024-03-10T17:43:58Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:10Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:10Z DEBUG blarun] Execution #1 finished in: 11.707455422s
+[2024-03-10T17:44:10Z DEBUG blarun] Computing verdict using "/tmp/.tmpUSN28B/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:10Z DEBUG blarun] Comparing output "/tmp/.tmpUSN28B/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:10Z DEBUG blarun] Starting execution #2
+[2024-03-10T17:44:10Z DEBUG blarun] The current started process has pid: 356212
+[2024-03-10T17:44:10Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:22Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:22Z DEBUG blarun] Execution #2 finished in: 11.708907864s
+[2024-03-10T17:44:22Z DEBUG blarun] Computing verdict using "/tmp/.tmpUSN28B/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:22Z DEBUG blarun] Comparing output "/tmp/.tmpUSN28B/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:22Z DEBUG blarun] Starting execution #3
+[2024-03-10T17:44:22Z DEBUG blarun] The current started process has pid: 356230
+[2024-03-10T17:44:22Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:33Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:33Z DEBUG blarun] Execution #3 finished in: 11.931635946s
+[2024-03-10T17:44:33Z DEBUG blarun] Computing verdict using "/tmp/.tmpUSN28B/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:33Z DEBUG blarun] Comparing output "/tmp/.tmpUSN28B/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:33Z DEBUG blarun] Starting execution #4
+[2024-03-10T17:44:33Z DEBUG blarun] The current started process has pid: 356248
+[2024-03-10T17:44:34Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:45Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:45Z DEBUG blarun] Execution #4 finished in: 11.751511056s
+[2024-03-10T17:44:45Z DEBUG blarun] Computing verdict using "/tmp/.tmpUSN28B/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:45Z DEBUG blarun] Comparing output "/tmp/.tmpUSN28B/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:44:45Z INFO  blarun] Submission from user: youssefhamdane has finished with verdict: Ac and with an AVG execution time of: 11.740351666s and MED of 11.751511056s
+[2024-03-10T17:44:45Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/NotAsheraf/solution.rs"
+[2024-03-10T17:44:46Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpxU031o/sol" with exit code: exit status: 0
+[2024-03-10T17:44:46Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356296
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 34.151937ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356313
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 20.424706ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356330
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 20.706222ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356347
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 20.963213ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356364
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 21.378231ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356381
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 22.541163ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356398
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 22.751837ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356415
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 21.100657ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356432
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 22.40121ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356449
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:44:46Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:44:46Z DEBUG blarun] Correctness execution finished in: 22.239855ms
+[2024-03-10T17:44:46Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:44:46Z DEBUG blarun] Comparing output "/tmp/.tmp2kWlAB/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:44:46Z INFO  blarun] Solution passed correctness checks
+[2024-03-10T17:44:46Z INFO  blarun] Symlinking file from: "/home/maxheap/blablaconf/input.txt" to "/tmp/.tmpxU031o/input.txt"
+[2024-03-10T17:44:46Z DEBUG blarun] Starting execution #0
+[2024-03-10T17:44:46Z DEBUG blarun] The current started process has pid: 356466
+[2024-03-10T17:44:46Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:45:21Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:45:21Z DEBUG blarun] Execution #0 finished in: 34.703830572s
+[2024-03-10T17:45:21Z DEBUG blarun] Computing verdict using "/tmp/.tmpxU031o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:45:21Z DEBUG blarun] Comparing output "/tmp/.tmpxU031o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:45:21Z DEBUG blarun] Starting execution #1
+[2024-03-10T17:45:21Z DEBUG blarun] The current started process has pid: 356483
+[2024-03-10T17:45:21Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:45:55Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:45:55Z DEBUG blarun] Execution #1 finished in: 34.705367291s
+[2024-03-10T17:45:55Z DEBUG blarun] Computing verdict using "/tmp/.tmpxU031o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:45:55Z DEBUG blarun] Comparing output "/tmp/.tmpxU031o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:45:55Z DEBUG blarun] Starting execution #2
+[2024-03-10T17:45:55Z DEBUG blarun] The current started process has pid: 356500
+[2024-03-10T17:45:55Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:46:30Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:46:30Z DEBUG blarun] Execution #2 finished in: 34.666459911s
+[2024-03-10T17:46:30Z DEBUG blarun] Computing verdict using "/tmp/.tmpxU031o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:46:30Z DEBUG blarun] Comparing output "/tmp/.tmpxU031o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:46:30Z DEBUG blarun] Starting execution #3
+[2024-03-10T17:46:30Z DEBUG blarun] The current started process has pid: 356517
+[2024-03-10T17:46:30Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:05Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:05Z DEBUG blarun] Execution #3 finished in: 34.744255626s
+[2024-03-10T17:47:05Z DEBUG blarun] Computing verdict using "/tmp/.tmpxU031o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:47:05Z DEBUG blarun] Comparing output "/tmp/.tmpxU031o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:47:05Z DEBUG blarun] Starting execution #4
+[2024-03-10T17:47:05Z DEBUG blarun] The current started process has pid: 356534
+[2024-03-10T17:47:05Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:40Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:40Z DEBUG blarun] Execution #4 finished in: 34.711896405s
+[2024-03-10T17:47:40Z DEBUG blarun] Computing verdict using "/tmp/.tmpxU031o/output.txt" and "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:47:40Z DEBUG blarun] Comparing output "/tmp/.tmpxU031o/output.txt" vs "/home/maxheap/blablaconf/output.txt"
+[2024-03-10T17:47:40Z INFO  blarun] Submission from user: NotAsheraf has finished with verdict: Ac and with an AVG execution time of: 34.707031422s and MED of 34.705367291s
+[2024-03-10T17:47:40Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/sickerine/solution.rs"
+[2024-03-10T17:47:40Z INFO  blarun] Finished compilation of the target: "/tmp/.tmpLJ65rA/sol" with exit code: exit status: 0
+[2024-03-10T17:47:40Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:47:40Z DEBUG blarun] The current started process has pid: 356579
+[2024-03-10T17:47:40Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:40Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:40Z DEBUG blarun] Correctness execution finished in: 41.805572ms
+[2024-03-10T17:47:40Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:47:40Z DEBUG blarun] Comparing output "/tmp/.tmp4usuMr/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:47:40Z DEBUG blarun] The current started process has pid: 356580
+[2024-03-10T17:47:40Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:40Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:40Z DEBUG blarun] Correctness execution finished in: 41.522935ms
+[2024-03-10T17:47:40Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:47:40Z DEBUG blarun] Comparing output "/tmp/.tmp4usuMr/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:47:40Z DEBUG blarun] The current started process has pid: 356581
+[2024-03-10T17:47:40Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:40Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:40Z DEBUG blarun] Correctness execution finished in: 42.024755ms
+[2024-03-10T17:47:40Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:47:40Z DEBUG blarun] Comparing output "/tmp/.tmp4usuMr/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:47:40Z INFO  blarun] Solution comparison failed, output for the solution is: El_Jadida 45848.19
+    Acorn_Squash 1.03
+    Eggplant 1.14
+    Sweet_Potato 1.35
+    Cactus_Pear 1.47
+    Watercress 1.49
+    
+     expected output is El_Jadida 45848.19
+    Acorn_Squash 1.03
+    Eggplant 1.14
+    Sweet_Potato 1.35
+    Cactus_Pear 1.47
+    Nectarine 1.49
+    
+    
+[2024-03-10T17:47:40Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T17:47:40Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T17:47:40Z INFO  blarun] Submission from user: sickerine has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T17:47:40Z DEBUG blarun] Changed path: "/home/maxheap/testdir/submissions/Hamdane-yassine/solution.rs"
+[2024-03-10T17:47:41Z INFO  blarun] Finished compilation of the target: "/tmp/.tmph7b8Qd/sol" with exit code: exit status: 0
+[2024-03-10T17:47:41Z INFO  blarun] Starting correctness checks
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356612
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 44.05115ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/01.in", output: "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/01.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356645
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 16.905408ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/02.in", output: "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/02.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356678
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 16.762949ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/03.in", output: "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/03.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356711
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 17.596081ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/04.in", output: "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/04.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356744
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 17.347831ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/05.in", output: "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/05.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356777
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 17.377449ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/06.in", output: "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/06.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356810
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 16.759253ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/07.in", output: "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/07.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356843
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 17.655611ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/08.in", output: "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/08.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356876
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 17.34543ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/09.in", output: "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/09.out"
+[2024-03-10T17:47:41Z DEBUG blarun] The current started process has pid: 356909
+[2024-03-10T17:47:41Z DEBUG blarun] Moved process to cgroup /sys/fs/cgroup/blarun.workload successfully
+[2024-03-10T17:47:41Z INFO  blarun] Finished execution of the solution with status: Some(0)
+[2024-03-10T17:47:41Z DEBUG blarun] Correctness execution finished in: 16.886943ms
+[2024-03-10T17:47:41Z DEBUG blarun] Found matching output_file: input: "/home/maxheap/correctness_tests/10.in", output: "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:47:41Z DEBUG blarun] Comparing output "/tmp/.tmpDn63gt/output.txt" vs "/home/maxheap/correctness_tests/10.out"
+[2024-03-10T17:47:41Z INFO  blarun] Solution comparison failed, output for the solution is: Errachidia 45507.77
+    Mint 1.03
+    Cherry 1.48
+    Dragon_Fruit 1.48
+    Raspberry 1.66
+    Jicama 1.75
+    
+     expected output is Errachidia 45642.45
+    Mint 1.03
+    Cherry 1.48
+    Dragon_Fruit 1.48
+    Raspberry 1.66
+    Jicama 1.75
+    
+    
+[2024-03-10T17:47:41Z INFO  blarun] Solution didn't pass correctness check, aborting early!
+[2024-03-10T17:47:41Z INFO  blarun] Solution failed correctness checks, exiting early
+[2024-03-10T17:47:41Z INFO  blarun] Submission from user: Hamdane-yassine has finished with verdict: Wa and with an AVG execution time of: 0ns and MED of 0ns
+[2024-03-10T17:47:41Z INFO  blarun] Writing latest commit: c5ca0c2fd568d6df6cf90b6f77ed995aa121dac2
+


### PR DESCRIPTION
There were some languages that had problems in the configured hosts (mainly wrong paths and unset correctness tests).

This has been fixed and a full re-run of the solutions has been performed.

This change adds the new log of the latest execution.